### PR TITLE
Add configs for lerna version/publish

### DIFF
--- a/.github/workflows/lerna-publish.yml
+++ b/.github/workflows/lerna-publish.yml
@@ -1,47 +1,27 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+name: Publish with Lerna
 
-name: Node.js Package
-
-on:
-  release:
-    types: [created]
+on: [workflow_dispatch]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm test
-
   publish-npm:
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: lerna publish
+      - name: Install dependencies
+        run: npm ci
+      - name: Lerna bootstrap
+        run: npm run lerna -- bootstrap
+      - name: Test
+        run: npm test
+      - name: Publish with Lerna
+        run: npm run lerna -- publish --yes --conventional-commits --create-release github
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
-
-  publish-gpr:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-          registry-url: https://npm.pkg.github.com/
-      - run: npm ci
-      - run: lerna publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -2,20 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent",
-  "command": {
-    "publish": {
-      "access": "public",
-      "conventionalCommits": true,
-      "createRelease": "github",
-      "signGitCommit": true,
-      "signGitTag": true
-    },
-    "version": {
-      "conventionalCommits": true,
-      "createRelease": "github",
-      "signGitCommit": true,
-      "signGitTag": true
-    }
-  }
+  "version": "independent"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,20 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent"
+  "version": "independent",
+  "command": {
+    "publish": {
+      "access": "public",
+      "conventionalCommits": true,
+      "createRelease": "github",
+      "signGitCommit": true,
+      "signGitTag": true
+    },
+    "version": {
+      "conventionalCommits": true,
+      "createRelease": "github",
+      "signGitCommit": true,
+      "signGitTag": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "root",
   "private": true,
   "scripts": {
+    "lerna": "lerna",
     "lint:es": "eslint .",
     "test": "ava"
   },


### PR DESCRIPTION
This adds a ~~few configs~~ CI action for manually publishing with Lerna. It includes the following parameters:

* [`conventionalCommits`](https://github.com/lerna/lerna/tree/master/commands/version#--conventional-commits) - required to generate changelogs.
* [`createRelease`](https://github.com/lerna/lerna/tree/master/commands/version#--create-release-type) - this will ensure that releases show up on GitHub.
* ~~[`signGitCommit`](https://github.com/lerna/lerna/tree/master/commands/version#--sign-git-commit) & [`signGitTag`](https://github.com/lerna/lerna/tree/master/commands/version#--sign-git-tag) - a measure of security for releases~~ (removed to avoid having to set up GPG for CI)