### PR TITLE
Docs Migration

### DIFF
--- a/docs/css-sass-style.md
+++ b/docs/css-sass-style.md
@@ -1,0 +1,283 @@
+---
+name: CSS/SASS Style
+route: /guides/css-sass-style
+menu: Guides
+---
+
+> W.W. Norton & Company recommends a slightly modified [Airbnb CSS / SASS styleguide](https://github.com/airbnb/css).
+
+# Airbnb CSS / Sass Styleguide
+
+## Terminology
+
+### Rule declaration
+
+A “rule declaration” is the name given to a selector (or a group of selectors) with an accompanying group of properties. Here's an example:
+
+```css
+.listing {
+  font-size: 18px;
+  line-height: 1.2;
+}
+```
+
+### Selectors
+
+In a rule declaration, “selectors” are the bits that determine which elements in the DOM tree will be styled by the defined properties. Selectors can match HTML elements, as well as an element's class, ID, or any of its attributes. Here are some examples of selectors:
+
+```css
+.my-element-class {
+  /* ... */
+}
+
+[aria-hidden] {
+  /* ... */
+}
+```
+
+### Properties
+
+Finally, properties are what give the selected elements of a rule declaration their style. Properties are key-value pairs, and a rule declaration can contain one or more property declarations. Property declarations look like this:
+
+```css
+/* some selector */ {
+  background: #f1f1f1;
+  color: #333;
+}
+```
+
+#### Use `em` or `rem` for `font-size:` property value
+
+W.W. Norton & Company strongly suggests using `em` or `rem` for font-size as opposed to `px` to ensure that font scaling works as expected accross devices. For all new projects, font sizes should be in em or rem.
+
+## CSS
+
+### Formatting
+
+* Use tabs for indentation.
+* Prefer dashes over camelCasing in class names.
+  - Underscores and PascalCasing are okay if you are using BEM (see [OOCSS and BEM](#oocss-and-bem) below).
+* Do not use ID selectors.
+* When using multiple selectors in a rule declaration, give each selector its own line.
+* Put a space before the opening brace `{` in rule declarations.
+* In properties, put a space after, but not before, the `:` character.
+* Put closing braces `}` of rule declarations on a new line.
+* Put blank lines between rule declarations.
+
+**Bad**
+
+```css
+.avatar{
+    border-radius:50%;
+    border:2px solid white; }
+.no, .nope, .not_good {
+    // ...
+}
+#lol-no {
+  // ...
+}
+```
+
+**Good**
+
+```css
+.avatar {
+  border-radius: 50%;
+  border: 2px solid white;
+}
+
+.one,
+.selector,
+.per-line {
+  // ...
+}
+```
+
+### Comments
+
+* Prefer line comments (`//` in Sass-land) to block comments.
+* Prefer comments on their own line. Avoid end-of-line comments.
+* Write detailed comments for code that isn't self-documenting:
+  - Uses of z-index
+  - Compatibility or browser-specific hacks
+
+### OOCSS and BEM
+
+We encourage some combination of OOCSS and BEM for these reasons:
+
+  * It helps create clear, strict relationships between CSS and HTML
+  * It helps us create reusable, composable components
+  * It allows for less nesting and lower specificity
+  * It helps in building scalable stylesheets
+
+**OOCSS**, or “Object Oriented CSS”, is an approach for writing CSS that encourages you to think about your stylesheets as a collection of “objects”: reusable, repeatable snippets that can be used independently throughout a website.
+
+  * Nicole Sullivan's [OOCSS wiki](https://github.com/stubbornella/oocss/wiki)
+  * Smashing Magazine's [Introduction to OOCSS](http://www.smashingmagazine.com/2011/12/12/an-introduction-to-object-oriented-css-oocss/)
+
+**BEM**, or “Block-Element-Modifier”, is a _naming convention_ for classes in HTML and CSS. It was originally developed by Yandex with large codebases and scalability in mind, and can serve as a solid set of guidelines for implementing OOCSS.
+
+  * CSS Trick's [BEM 101](https://css-tricks.com/bem-101/)
+  * Harry Roberts' [introduction to BEM](http://csswizardry.com/2013/01/mindbemding-getting-your-head-round-bem-syntax/)
+
+We recommend a variant of BEM with PascalCased “blocks”, which works particularly well when combined with components (e.g. React). Underscores and dashes are still used for modifiers and children.
+
+**Example**
+
+```jsx
+// ListingCard.jsx
+function ListingCard() {
+  return (
+    <article class="ListingCard ListingCard--featured">
+
+      <h1 class="ListingCard__title">Adorable 2BR in the sunny Mission</h1>
+
+      <div class="ListingCard__content">
+        <p>Vestibulum id ligula porta felis euismod semper.</p>
+      </div>
+
+    </article>
+  );
+}
+```
+
+```css
+/* ListingCard.css */
+.ListingCard { }
+.ListingCard--featured { }
+.ListingCard__title { }
+.ListingCard__content { }
+```
+
+  * `.ListingCard` is the “block” and represents the higher-level component
+  * `.ListingCard__title` is an “element” and represents a descendant of `.ListingCard` that helps compose the block as a whole.
+  * `.ListingCard--featured` is a “modifier” and represents a different state or variation on the `.ListingCard` block.
+
+### ID selectors
+
+While it is possible to select elements by ID in CSS, it should generally be considered an anti-pattern. ID selectors introduce an unnecessarily high level of [specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) to your rule declarations, and they are not reusable.
+
+For more on this subject, read [CSS Wizardry's article](http://csswizardry.com/2014/07/hacks-for-dealing-with-specificity/) on dealing with specificity.
+
+### JavaScript hooks
+
+Avoid binding to the same class in both your CSS and JavaScript. Conflating the two often leads to, at a minimum, time wasted during refactoring when a developer must cross-reference each class they are changing, and at its worst, developers being afraid to make changes for fear of breaking functionality.
+
+We recommend creating JavaScript-specific classes to bind to, prefixed with `.js-`:
+
+```html
+<button class="btn btn-primary js-request-to-book">Request to Book</button>
+```
+
+### Border
+
+Use `0` instead of `none` to specify that a style has no border.
+
+**Bad**
+
+```css
+.foo {
+  border: none;
+}
+```
+
+**Good**
+
+```css
+.foo {
+  border: 0;
+}
+```
+
+## Sass
+
+### Syntax
+
+* Use the `.scss` syntax, never the original `.sass` syntax
+* Order your regular CSS and `@include` declarations logically (see below)
+
+### Ordering of property declarations
+
+> W.W. Norton & Company's property ordering style is inspired by [the order from GitHub's Primer design system](https://github.com/primer/primer/blob/master/tools/stylelint-config-primer/index.js#L47-L217) instead of alphabetical.
+W.W. Norton also adds and groups accessibility properties to the bottom of that list. This list can be found on our [Github repository](https://github.com/wwnorton/style/blob/main/packages/stylelint-config-norton/src/rules/plugins/property-order.js).
+
+1. Property declarations
+
+    List all standard property declarations, anything that isn't an `@include` or a nested selector.
+
+    ```scss
+    .btn-green {
+      font-weight: bold;
+      background: 'green';
+      // ...
+    }
+    ```
+
+
+2. `@include` declarations
+
+    Grouping `@include`s at the end makes it easier to read the entire selector.
+
+    ```scss
+    .btn-green {
+      font-weight: bold;
+      background: 'green';
+
+      @include transition(background 0.5s ease);
+      // ...
+    }
+    ```
+
+3. Nested selectors
+
+    Nested selectors, _if necessary_, go last, and nothing goes after them. Add whitespace between your rule declarations and nested selectors, as well as between adjacent nested selectors. Apply the same guidelines as above to your nested selectors.
+
+    ```scss
+	.btn {
+		font-weight: bold;
+		background: 'green';
+
+		@include transition(background 0.5s ease);
+
+		.icon {
+			margin-right: 10px;
+		}
+	}
+    ```
+
+### Variables
+
+Prefer dash-cased variable names (e.g. `$my-variable`) over camelCased or snake_cased variable names. It is acceptable to prefix variable names that are intended to be used only within the same file with an underscore (e.g. `$_my-variable`).
+
+### Mixins
+
+Mixins should be used to DRY up your code, add clarity, or abstract complexity--in much the same way as well-named functions. Mixins that accept no arguments can be useful for this, but note that if you are not compressing your payload (e.g. gzip), this may contribute to unnecessary code duplication in the resulting styles.
+
+### Extend directive
+
+`@extend` should be avoided because it has unintuitive and potentially dangerous behavior, especially when used with nested selectors. Even extending top-level placeholder selectors can cause problems if the order of selectors ends up changing later (e.g. if they are in other files and the order the files are loaded shifts). Gzipping should handle most of the savings you would have gained by using `@extend`, and you can DRY up your stylesheets nicely with mixins.
+
+### Nested selectors
+
+**Do not nest selectors more than three levels deep!**
+
+```scss
+.page-container {
+  .content {
+    .profile {
+      // STOP!
+    }
+  }
+}
+```
+
+When selectors become this long, you're likely writing CSS that is:
+
+* Strongly coupled to the HTML (fragile) *—OR—*
+* Overly specific (powerful) *—OR—*
+* Not reusable
+
+
+Again: **never nest ID selectors!**
+
+If you must use an ID selector in the first place (and you should really try not to), they should never be nested. If you find yourself doing this, you need to revisit your markup, or figure out why such strong specificity is needed. If you are writing well formed HTML and CSS, you should **never** need to do this.

--- a/docs/javascript-style.md
+++ b/docs/javascript-style.md
@@ -1,0 +1,3996 @@
+---
+name: JavaScript Style
+route: /guides/javascript-style
+menu: Guides
+---
+
+# JavaScript Style
+
+> A guide for writing consistent and aesthetically pleasing JavaScript.
+
+Inspired by other popular styles such as [`eslint:recommended`](https://eslint.org/docs/rules/), and [Airbnb](https://github.com/airbnb/javascript/#airbnb-javascript-style-guide-).
+
+## Formatting
+
+### Tabs for indentation
+
+Use tabs for indenting your code. With tabs users can choose their desired width. This has positive implications for accessibility and screenreaders, putting people in control of how they want to view the code.
+
+### Newlines
+
+Use UNIX-style newlines (`\n`), and a newline character as the last character of a file. Windows-style newlines (`\r\n`) are forbidden inside any repository.
+
+### No trailing whitespace
+
+Always clean up any trailing whitespace in your .js files before committing.
+
+### Use semicolons
+
+According to scientific research, the usage of semicolons is a core value of our community. Consider the points of the opposition, but be a traditionalist when it comes to abusing error correction mechanisms for cheap syntactic pleasures.
+
+### 80 characters per line
+
+Limit your lines to 80 characters. Yes, screens have gotten much bigger over the last few years, but your brain has not. Use the additional room for split screen, your editor supports that, right?
+
+### Use single quotes
+
+Use single quotes, unless you are writing JSON. This helps you separate your objects' strings from normal strings.
+
+
+```js
+// bad 👎
+var foo = "bad";
+
+// good 👍
+var foo = 'bar';
+```
+
+
+Opening braces go on the same line, Your opening braces go on the same line as the statement.
+
+
+```js
+// bad 👎
+if (true)
+{
+    console.log('losing');
+}
+
+// good 👍
+if (true) {
+    console.log('winning');
+}
+```
+
+
+Also, notice the use of whitespace before and after the condition statement. What if you want to write 'else' or 'else if' along with your 'if'...
+
+
+```js
+// bad 👎
+if (true)
+{
+    console.log('losing');
+}
+else if (false)
+{
+    console.log('this is bad');
+}
+else
+{
+    console.log('not good');
+}
+
+// good 👍
+if (true) {
+    console.log('winning');
+} else if (false) {
+    console.log('this is good');
+} else {
+    console.log('finally');
+}
+```
+
+
+### Declare one variable per var statement
+
+Declare one variable per var statement, it makes it easier to re-order the lines.
+
+
+```js
+// bad 👎
+var keys = ['foo', 'bar'],
+values = [23, 42],
+object = {},
+key;
+
+// good 👍
+var keys = ['foo', 'bar'];
+var values = [23, 42];
+var object = {};
+```
+
+
+## Whitespace
+
+### Use tabs.
+eslint: [`indent`](https://eslint.org/docs/rules/indent.html)
+
+```javascript
+// bad 👎
+function foo() {
+∙∙let name;
+}
+
+// bad 👎
+function bar() {
+∙let name;
+}
+
+// good 👍
+function baz() {
+∙ let name;
+}
+```
+
+### Place 1 space before the leading brace.
+eslint: [`space-before-blocks`](https://eslint.org/docs/rules/space-before-blocks.html)
+
+```javascript
+// bad 👎
+function test(){
+	console.log('test');
+}
+
+// good 👍
+function test() {
+	console.log('test');
+}
+
+// bad 👎
+dog.set('attr',{
+	age: '1 year',
+	breed: 'Bernese Mountain Dog',
+});
+
+// good 👍
+dog.set('attr', {
+	age: '1 year',
+	breed: 'Bernese Mountain Dog',
+});
+```
+
+### Place 1 space before the opening parenthesis in control statements (`if`, `while` etc.). Place no space between the argument list and the function name in function calls and declarations.
+eslint: [`keyword-spacing`](https://eslint.org/docs/rules/keyword-spacing.html)
+
+```javascript
+// bad 👎
+if(isJedi) {
+	fight ();
+}
+
+// good 👍
+if (isJedi) {
+	fight();
+}
+
+// bad 👎
+function fight () {
+	console.log ('Swooosh!');
+}
+
+// good 👍
+function fight() {
+	console.log('Swooosh!');
+}
+```
+
+### Set off operators with spaces.
+eslint: [`space-infix-ops`](https://eslint.org/docs/rules/space-infix-ops.html)
+
+```javascript
+// bad 👎
+const x=y+5;
+
+// good 👍
+const x = y + 5;
+```
+
+### End files with a single newline character.
+eslint: [`eol-last`](https://github.com/eslint/eslint/blob/master/docs/rules/eol-last.md)
+
+```javascript
+// bad 👎
+import { es6 } from './AirbnbStyleGuide';
+	// ...
+export default es6;
+```
+
+```javascript
+// bad 👎
+import { es6 } from './AirbnbStyleGuide';
+	// ...
+export default es6;↵
+↵
+```
+
+```javascript
+// good 👍
+import { es6 } from './AirbnbStyleGuide';
+	// ...
+export default es6;↵
+```
+
+### Use indentation when making long method chains (more than 2 method chains). Use a leading dot, which emphasizes that the line is a method call, not a new statement.
+eslint: [`newline-per-chained-call`](https://eslint.org/docs/rules/newline-per-chained-call) [`no-whitespace-before-property`](https://eslint.org/docs/rules/no-whitespace-before-property)
+
+```javascript
+// bad 👎
+$('#items').find('.selected').highlight().end().find('.open').updateCount();
+
+// bad 👎
+$('#items').
+  find('.selected').
+	highlight().
+	end().
+  find('.open').
+	updateCount();
+
+// good 👍
+$('#items')
+  .find('.selected')
+	.highlight()
+	.end()
+  .find('.open')
+	.updateCount();
+
+// bad 👎
+const leds = stage.selectAll('.led').data(data).enter().append('svg:svg').classed('led', true)
+	.attr('width', (radius + margin) * 2).append('svg:g')
+	.attr('transform', `translate(${radius + margin},${radius + margin})`)
+	.call(tron.led);
+
+// good 👍
+const leds = stage.selectAll('.led')
+	.data(data)
+  .enter().append('svg:svg')
+	.classed('led', true)
+	.attr('width', (radius + margin) * 2)
+  .append('svg:g')
+	.attr('transform', `translate(${radius + margin},${radius + margin})`)
+	.call(tron.led);
+
+// good 👍
+const leds = stage.selectAll('.led').data(data);
+```
+
+### Leave a blank line after blocks and before the next statement.
+
+```javascript
+// bad 👎
+if (foo) {
+  return bar;
+}
+return baz;
+
+// good 👍
+if (foo) {
+  return bar;
+}
+
+return baz;
+
+// bad 👎
+const obj = {
+  foo() {
+  },
+  bar() {
+  },
+};
+return obj;
+
+// good 👍
+const obj = {
+  foo() {
+  },
+
+  bar() {
+  },
+};
+
+return obj;
+
+// bad 👎
+const arr = [
+  function foo() {
+  },
+  function bar() {
+  },
+];
+return arr;
+
+// good 👍
+const arr = [
+  function foo() {
+  },
+
+  function bar() {
+  },
+];
+
+return arr;
+```
+
+### Do not pad your blocks with blank lines.
+eslint: [`padded-blocks`](https://eslint.org/docs/rules/padded-blocks.html)
+
+```javascript
+// bad 👎
+function bar() {
+
+  console.log(foo);
+
+}
+
+// bad 👎
+if (baz) {
+
+  console.log(qux);
+} else {
+  console.log(foo);
+
+}
+
+// bad 👎
+class Foo {
+
+  constructor(bar) {
+	this.bar = bar;
+  }
+}
+
+// good 👍
+function bar() {
+  console.log(foo);
+}
+
+// good 👍
+if (baz) {
+  console.log(qux);
+} else {
+  console.log(foo);
+}
+```
+
+### Do not use multiple blank lines to pad your code.
+eslint: [`no-multiple-empty-lines`](https://eslint.org/docs/rules/no-multiple-empty-lines)
+
+```javascript
+// bad 👎
+class Person {
+  constructor(fullName, email, birthday) {
+    this.fullName = fullName;
+
+
+    this.email = email;
+
+
+    this.setAge(birthday);
+  }
+
+
+  setAge(birthday) {
+    const today = new Date();
+
+
+    const age = this.getAge(today, birthday);
+
+
+    this.age = age;
+  }
+
+
+  getAge(today, birthday) {
+    // ..
+  }
+}
+
+// good 👍
+class Person {
+  constructor(fullName, email, birthday) {
+	this.fullName = fullName;
+	this.email = email;
+	this.setAge(birthday);
+  }
+
+  setAge(birthday) {
+	const today = new Date();
+	const age = getAge(today, birthday);
+	this.age = age;
+  }
+
+  getAge(today, birthday) {
+	// ..
+  }
+}
+```
+
+### Do not add spaces inside parentheses.
+eslint: [`space-in-parens`](https://eslint.org/docs/rules/space-in-parens.html)
+
+```javascript
+// bad 👎
+function bar( foo ) {
+  return foo;
+}
+
+// good 👍
+function bar(foo) {
+  return foo;
+}
+
+// bad 👎
+if ( foo ) {
+  console.log(foo);
+}
+
+// good 👍
+if (foo) {
+  console.log(foo);
+}
+```
+
+### Do not add spaces inside brackets.
+eslint: [`array-bracket-spacing`](https://eslint.org/docs/rules/array-bracket-spacing.html)
+
+```javascript
+// bad 👎
+const foo = [ 1, 2, 3 ];
+console.log(foo[ 0 ]);
+
+// good 👍
+const foo = [1, 2, 3];
+console.log(foo[0]);
+```
+
+### Add spaces inside curly braces.
+eslint: [`object-curly-spacing`](https://eslint.org/docs/rules/object-curly-spacing.html)
+
+```javascript
+// bad 👎
+const foo = {clark: 'kent'};
+
+// good 👍
+const foo = { clark: 'kent' };
+```
+
+### Avoid having lines of code that are longer than 80 characters (including whitespace). Note: long strings are exempt from this rule, and should not be broken up.
+eslint: [`max-len`](https://eslint.org/docs/rules/max-len.html)
+> Why? This ensures readability and maintainability.
+
+```javascript
+// bad 👎
+const foo = jsonData && jsonData.foo && jsonData.foo.bar && jsonData.foo.bar.baz && jsonData.foo.bar.baz.quux && jsonData.foo.bar.baz.quux.xyzzy;
+
+// bad 👎
+$.ajax({ method: 'POST', url: 'https://airbnb.com/', data: { name: 'John' } }).done(() => console.log('Congratulations!')).fail(() => console.log('You have failed this city.'));
+
+// good 👍
+const foo = jsonData
+  && jsonData.foo
+  && jsonData.foo.bar
+  && jsonData.foo.bar.baz
+  && jsonData.foo.bar.baz.quux
+  && jsonData.foo.bar.baz.quux.xyzzy;
+
+// good 👍
+$.ajax({
+  method: 'POST',
+  url: 'https://airbnb.com/',
+  data: { name: 'John' },
+})
+  .done(() => console.log('Congratulations!'))
+  .fail(() => console.log('You have failed this city.'));
+```
+
+### Require consistent spacing inside an open block token and the next token on the same line. This rule also enforces consistent spacing inside a close block token and previous token on the same line.
+eslint: [`block-spacing`](https://eslint.org/docs/rules/block-spacing)
+
+```javascript
+// bad 👎
+function foo() {return true;}
+if (foo) { bar = 0;}
+
+// good 👍
+function foo() { return true; }
+if (foo) { bar = 0; }
+```
+
+### Avoid spaces before commas and require a space after commas.
+eslint: [`comma-spacing`](https://eslint.org/docs/rules/comma-spacing)
+
+```javascript
+// bad 👎
+var foo = 1,bar = 2;
+var arr = [1 , 2];
+
+// good 👍
+var foo = 1, bar = 2;
+var arr = [1, 2];
+```
+
+### Enforce spacing inside of computed property brackets.
+eslint: [`computed-property-spacing`](https://eslint.org/docs/rules/computed-property-spacing)
+
+```javascript
+// bad 👎
+obj[foo ]
+obj[ 'foo']
+var x = {[ b ]: a}
+obj[foo[ bar ]]
+
+// good 👍
+obj[foo]
+obj['foo']
+var x = { [b]: a }
+obj[foo[bar]]
+```
+
+### Avoid spaces between functions and their invocations.
+eslint: [`func-call-spacing`](https://eslint.org/docs/rules/func-call-spacing)
+
+```javascript
+// bad 👎
+func ();
+
+func
+();
+
+// good 👍
+func();
+```
+
+### Enforce spacing between keys and values in object literal properties.
+eslint: [`key-spacing`](https://eslint.org/docs/rules/key-spacing)
+
+```javascript
+// bad 👎
+var obj = { foo : 42 };
+var obj2 = { foo:42 };
+
+// good 👍
+var obj = { foo: 42 };
+```
+
+### Avoid trailing spaces at the end of lines.
+eslint: [`no-trailing-spaces`](https://eslint.org/docs/rules/no-trailing-spaces)
+
+### Avoid multiple empty lines, only allow one newline at the end of files, and avoid a newline at the beginning of files.
+eslint: [`no-multiple-empty-lines`](https://eslint.org/docs/rules/no-multiple-empty-lines)
+
+```javascript
+// bad 👎 - multiple empty lines
+var x = 1;
+
+
+var y = 2;
+
+// bad 👎 - 2+ newlines at end of file
+var x = 1;
+var y = 2;
+
+
+// bad 👎 - 1+ newline(s) at beginning of file
+
+var x = 1;
+var y = 2;
+
+// good 👍
+var x = 1;
+var y = 2;
+```
+
+## Types
+
+### Primitives
+
+When you access a primitive type you work directly on its value.
+
+- `string`
+- `number`
+- `boolean`
+- `null`
+- `undefined`
+- `symbol`
+- `bigint`
+
+
+```js
+const foo = 1;
+let bar = foo;
+
+bar = 9;
+
+console.log(foo, bar); // => 1, 9
+```
+
+
+- Symbols and BigInts cannot be faithfully polyfilled, so they should not be used when targeting browsers/environments that don't support them natively.
+
+### Complex:
+
+When you access a complex type you work on a reference to its value.
+
+- `object`
+- `array`
+- `function`
+
+
+```js
+const foo = [1, 2];
+const bar = foo;
+
+bar[0] = 9;
+
+console.log(foo[0], bar[0]); // => 9, 9
+```
+
+
+## References
+
+### Use `const` for all of your references:
+
+avoid using `var`. eslint: [`prefer-const`](https://eslint.org/docs/rules/prefer-const.html), [`no-const-assign`](https://eslint.org/docs/rules/no-const-assign.html)
+
+> IMPORTANCE: This ensures that you can't reassign your references, which can lead to bugs and difficult to comprehend code.
+
+
+```js
+// bad 👎
+var a = 1;
+var b = 2;
+
+// good 👍
+const a = 1;
+const b = 2;
+```
+
+
+### Use `let` instead of `var`.
+
+If you must reassign references, use 'let' instead of 'var'. eslint: [`no-var`](https://eslint.org/docs/rules/no-var.html)
+
+> IMPORTANCE: `let` is block-scoped rather than function-scoped like `var`.
+
+
+```js
+// bad 👎
+var count = 1;
+if (true) {
+  count += 1;
+}
+
+// good 👍 , use the let.
+let count = 1;
+if (true) {
+  count += 1;
+}
+```
+
+
+### Note that both `let` and `const` are block-scoped.
+
+
+```js
+// const and let only exist in the blocks they are defined in.
+{
+  let a = 1;
+  const b = 1;
+}
+console.log(a); // ReferenceError
+console.log(b); // ReferenceError
+```
+
+
+## Objects
+
+### Use the literal syntax for object creation.
+
+eslint: [`no-new-object`](https://eslint.org/docs/rules/no-new-object.html)
+
+
+```js
+// bad 👎
+const item = new Object();
+
+// good 👍
+const item = {};
+```
+
+
+### Use computed property names when creating objects with dynamic property names.
+
+> IMPORTANCE: They allow you to define all the properties of an object in one place.
+
+
+```js
+function getKey(k) {
+  return `a key named ${k}`;
+}
+
+// bad 👎
+const obj = {
+  id: 5,
+  name: 'Lorem Ipsum',
+};
+obj[getKey('enabled')] = true;
+
+// good 👍
+const obj = {
+  id: 5,
+  name: 'Lorem Ipsum',
+  [getKey('enabled')]: true,
+};
+```
+
+
+### Use object method shorthand.
+
+eslint: [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand.html)
+
+
+```js
+// bad 👎
+const atom = {
+  value: 1,
+
+  addValue: function (value) {
+    return atom.value + value;
+  },
+};
+
+// good 👍
+const atom = {
+  value: 1,
+
+  addValue(value) {
+    return atom.value + value;
+  },
+};
+```
+
+
+### Use property value shorthand.
+
+eslint: [`object-shorthand`](https://eslint.org/docs/rules/object-shorthand.html)
+
+> IMPORTANCE: It is shorter and descriptive.
+
+
+```js
+const lukeSkywalker = 'Lorem Ipsum';
+
+// bad 👎
+const obj = {
+  lukeSkywalker: lukeSkywalker,
+};
+
+// good 👍
+const obj = {
+  lukeSkywalker,
+};
+```
+
+
+### Group your shorthand properties at the beginning of your object declaration.
+
+> IMPORTANCE: It's easier to tell which properties are using the shorthand.
+
+
+```js
+const newyorkSubway = 'Newyork Subway';
+const newjerseyTransit = 'NewJersy Transit';
+
+// bad 👎
+const obj = {
+  episodeOne: 1,
+  twoJediWalkIntoACantina: 2,
+  newjerseyTransit,
+  episodeThree: 3,
+  mayTheFourth: 4,
+  newyorkSubway,
+};
+
+// good 👍
+const obj = {
+  newjerseyTransit,
+  newyorkSubway,
+  episodeOne: 1,
+  twoJediWalkIntoACantina: 2,
+  episodeThree: 3,
+  mayTheFourth: 4,
+};
+```
+
+
+### Only quote properties that are invalid identifiers.
+
+eslint: [`quote-props`](https://eslint.org/docs/rules/quote-props.html)
+
+> IMPORTANCE: In general we consider it subjectively easier to read. It improves syntax highlighting, and is also more easily optimized by many JS engines.
+
+
+```js
+// bad 👎
+const bad = {
+  'foo': 3,
+  'bar': 4,
+  'data-blah': 5,
+};
+
+// good 👍
+const good = {
+  foo: 3,
+  bar: 4,
+  'data-blah': 5,
+};
+```
+
+
+### Do not call `Object.prototype` methods directly,
+
+such as `hasOwnProperty`, `propertyIsEnumerable`, and `isPrototypeOf`. eslint: [`no-prototype-builtins`](https://eslint.org/docs/rules/no-prototype-builtins)
+
+> IMPORTANCE: These methods may be shadowed by properties on the object in question - consider `{ hasOwnProperty: false }` - or, the object may be a null object (`Object.create(null)`).
+
+
+```js
+// bad 👎
+console.log(object.hasOwnProperty(key));
+
+// good 👍
+console.log(Object.prototype.hasOwnProperty.call(object, key));
+
+// best
+const has = Object.prototype.hasOwnProperty; // cache the lookup once, in module scope.
+console.log(has.call(object, key));
+/* or */
+import has from 'has'; // https://www.npmjs.com/package/has
+console.log(has(object, key));
+```
+
+
+### Prefer the object spread operator.
+
+over [`Object.assign`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) to shallow-copy objects. Use the object rest operator to get a new object with certain properties omitted.
+
+
+```js
+// very bad 👎👎
+const original = { a: 1, b: 2 };
+const copy = Object.assign(original, { c: 3 }); // this mutates `original` à² _à²
+delete copy.a; // so does this
+
+// bad 👎
+const original = { a: 1, b: 2 };
+const copy = Object.assign({}, original, { c: 3 }); // copy => { a: 1, b: 2, c: 3 }
+
+// good 👍
+const original = { a: 1, b: 2 };
+const copy = { ...original, c: 3 }; // copy => { a: 1, b: 2, c: 3 }
+
+const { a, ...noA } = copy; // noA => { b: 2, c: 3 }
+```
+
+
+## Arrays
+
+### Use the literal syntax for array creation.
+
+eslint: [`no-array-constructor`](https://eslint.org/docs/rules/no-array-constructor.html)
+
+
+```js
+// bad 👎
+const items = new Array();
+
+// good 👍
+const items = [];
+```
+
+
+### Use Arraypush
+
+[Array#push](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/push) instead of direct assignment to add items to an array.
+
+
+```js
+const someStack = [];
+
+// bad 👎
+someStack[someStack.length] = 'abracadabra';
+
+// good 👍
+someStack.push('abracadabra');
+```
+
+
+### Use array spreads `...` to copy arrays.
+
+
+```js
+// bad 👎
+const len = items.length;
+const itemsCopy = [];
+let i;
+
+for (i = 0; i < len; i += 1) {
+  itemsCopy[i] = items[i];
+}
+
+// good 👍
+const itemsCopy = [...items];
+```
+
+
+### To convert an iterable object to an array, use spreads `...` instead of Array.from
+
+[`Array.from`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+
+
+```js
+const foo = document.querySelectorAll('.foo');
+
+// good 👍
+const nodes = Array.from(foo);
+
+// best
+const nodes = [...foo];
+```
+
+
+### Use Array.from
+
+[`Array.from`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from) for converting an array-like object to an array.
+
+
+```js
+const arrLike = { 0: 'foo', 1: 'bar', 2: 'baz', length: 3 };
+
+// bad 👎
+const arr = Array.prototype.slice.call(arrLike);
+
+// good 👍
+const arr = Array.from(arrLike);
+```
+
+
+### Use [`Array.from`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/from) instead of spread `...` for mapping over iterables, because it avoids creating an intermediate array.
+
+
+```js
+// bad 👎
+const baz = [...foo].map(bar);
+
+// good 👍
+const baz = Array.from(foo, bar);
+```
+
+
+### Use return statements in array method callbacks.
+
+It's ok to omit the return if the function body consists of a single statement returning an expression without side effects, following [8.2](#arrows--implicit-return). eslint: [`array-callback-return`](https://eslint.org/docs/rules/array-callback-return)
+
+
+```js
+// good 👍
+[1, 2, 3].map((x) => {
+  const y = x + 1;
+  return x * y;
+});
+
+// good 👍
+[1, 2, 3].map((x) => x + 1);
+
+// bad 👎 - no returned value means `acc` becomes undefined after the first iteration
+[[0, 1], [2, 3], [4, 5],].reduce((acc, item, index) => {
+  const flatten = acc.concat(item);
+});
+
+// good 👍
+[[0, 1], [2, 3], [4, 5],].reduce((acc, item, index) => {
+  const flatten = acc.concat(item);
+  return flatten;
+});
+
+// bad 👎
+inbox.filter((msg) => {
+  const { subject, author } = msg;
+  if (subject === 'Mockingbird') {
+    return author === 'Harper Lee';
+  } else {
+    return false;
+  }
+});
+
+// good 👍
+inbox.filter((msg) => {
+  const { subject, author } = msg;
+  if (subject === 'Mockingbird') {
+    return author === 'Harper Lee';
+  }
+
+  return false;
+});
+```
+
+
+### Use line breaks after open and before close array brackets if an array has multiple lines
+
+
+```js
+// bad 👎
+const arr = [
+  [0, 1], [2, 3], [4, 5],
+];
+
+const objectInArray = [{
+  id: 1,
+}, {
+  id: 2,
+}];
+
+const numberInArray = [
+  1, 2
+];
+
+// good 👍
+const arr = [[0, 1], [2, 3], [4, 5]];
+
+const objectInArray = [
+  {
+    id: 1,
+  },
+  {
+    id: 2,
+  },
+];
+
+const numberInArray = [
+  1,
+  2
+];
+```
+
+
+## Destructuring
+
+### Use object destructuring when accessing and using multiple properties of an object.
+
+eslint: [`prefer-destructuring`](https://eslint.org/docs/rules/prefer-destructuring)
+
+> IMPORTANCE: Destructuring saves you from creating temporary references for those properties.
+
+
+```js
+// bad 👎
+function getFullName(user) {
+  const firstName = user.firstName;
+  const lastName = user.lastName;
+
+  return `${firstName} ${lastName}`;
+}
+
+// good 👍
+function getFullName(user) {
+  const { firstName, lastName } = user;
+  return `${firstName} ${lastName}`;
+}
+
+// best
+function getFullName({ firstName, lastName }) {
+  return `${firstName} ${lastName}`;
+}
+```
+
+
+### Use array destructuring.
+
+eslint: [`prefer-destructuring`](https://eslint.org/docs/rules/prefer-destructuring)
+
+
+```js
+const arr = [1, 2, 3, 4];
+
+// bad 👎
+const first = arr[0];
+const second = arr[1];
+
+// good 👍
+const [first, second] = arr;
+```
+
+
+### Use object destructuring for multiple return values, not array destructuring.
+
+> IMPORTANCE: You can add new properties over time or change the order of things without breaking call sites.
+
+
+```js
+// bad 👎
+function processInput(input) {
+  // then a miracle occurs
+  return [left, right, top, bottom];
+}
+
+// the caller needs to think about the order of return data
+const [left, __, top] = processInput(input);
+
+// good 👍
+function processInput(input) {
+  // then a miracle occurs
+  return { left, right, top, bottom };
+}
+
+// the caller selects only the data they need
+const { left, top } = processInput(input);
+```
+
+
+## Strings
+
+### Use single quotes `''` for strings.
+
+eslint: [`quotes`](https://eslint.org/docs/rules/quotes.html)
+
+
+```js
+// bad 👎
+const name = 'Capt. Janeway';
+
+// bad 👎 - template literals should contain interpolation or newlines
+const name = `Capt. Janeway`;
+
+// good 👍
+const name = 'Capt. Janeway';
+```
+
+
+### Strings that cause the line to go over 80 characters should not be written across multiple lines using string concatenation.
+
+> IMPORTANCE: Broken strings are painful to work with and make code less searchable.
+
+
+```js
+// bad 👎
+const errorMessage = 'This is a super long error that was thrown because \
+of Batman. When you stop to think about how Batman had anything to do \
+with this, you would get nowhere \
+fast.';
+
+// bad 👎
+const errorMessage = 'This is a super long error that was thrown because ' +
+  'of Batman. When you stop to think about how Batman had anything to do ' +
+  'with this, you would get nowhere fast.';
+
+// good 👍
+const errorMessage =
+  'This is a super long error that was thrown because of Batman. When you stop to think about how Batman had anything to do with this, you would get nowhere fast.';
+```
+
+
+### When programmatically building up strings, use template strings instead of concatenation.
+
+eslint: [`prefer-template`](https://eslint.org/docs/rules/prefer-template.html) [`template-curly-spacing`](https://eslint.org/docs/rules/template-curly-spacing)
+
+> IMPORTANCE: Template strings give you a readable, concise syntax with proper newlines and string interpolation features.
+
+
+```js
+// bad 👎
+function sayHi(name) {
+  return 'How are you, ' + name + '?';
+}
+
+// bad 👎
+function sayHi(name) {
+  return ['How are you, ', name, '?'].join();
+}
+
+// bad 👎
+function sayHi(name) {
+  return `How are you, ${name}?`;
+}
+
+// good 👍
+function sayHi(name) {
+  return `How are you, ${name}?`;
+}
+```
+
+
+### Never use `eval()` on a string, it opens too many vulnerabilities.
+
+eslint: [`no-eval`](https://eslint.org/docs/rules/no-eval)
+
+### Do not unnecessarily escape characters in strings.
+
+eslint: [`no-useless-escape`](https://eslint.org/docs/rules/no-useless-escape)
+
+> IMPORTANCE: Backslashes harm readability, thus they should only be present when necessary.
+
+
+```js
+// bad 👎
+const foo = ''this' is \'quoted\'';
+
+// good 👍
+const foo = ''this' is \'quoted\'';
+const foo = `my name is '${name}'`;
+```
+
+
+## Functions
+
+### Use named function expressions instead of function declarations.
+
+eslint: [`func-style`](https://eslint.org/docs/rules/func-style)
+
+> IMPORTANCE: Function declarations are hoisted, which means that it's easy - too easy - to reference the function before it is defined in the file. This harms readability and maintainability.
+
+
+```js
+// bad 👎
+function foo() {
+  // ...
+}
+
+// bad 👎
+const foo = function () {
+  // ...
+};
+
+// good 👍
+// lexical name distinguished from the variable-referenced invocation(s)
+const short = function longUniqueMoreDescriptiveLexicalFoo() {
+  // ...
+};
+```
+
+
+### Wrap immediately invoked function expressions in parentheses.
+
+eslint: [`wrap-iife`](https://eslint.org/docs/rules/wrap-iife.html)
+
+> IMPORTANCE: An immediately invoked function expression is a single unit - wrapping both it, and its invocation parens, in parens, cleanly expresses this. Note that in a world with modules everywhere, you almost never need an IIFE.
+
+
+```js
+// immediately-invoked function expression (IIFE)
+(function () {
+  console.log('Welcome to the Internet. Please follow me.');
+})();
+```
+
+
+### Never declare a function in a non-function block
+
+(`if`, `while`, etc). Assign the function to a variable instead.
+
+eslint: [`no-loop-func`](https://eslint.org/docs/rules/no-loop-func.html)
+
+
+### A function declaration is not a statement.
+
+
+```js
+// bad 👎
+if (currentUser) {
+  function test() {
+    console.log('Nope.');
+  }
+}
+
+// good 👍
+let test;
+if (currentUser) {
+  test = () => {
+    console.log('Yup.');
+  };
+}
+```
+
+
+### Never name a parameter `arguments`. This will take precedence over the `arguments` object that is given to every function scope.
+
+
+```js
+// bad 👎
+function foo(name, options, arguments) {
+  // ...
+}
+
+// good 👍
+function foo(name, options, args) {
+  // ...
+}
+```
+
+
+### Never use `arguments`, opt to use rest syntax `...` instead.
+
+eslint: [`prefer-rest-params`](https://eslint.org/docs/rules/prefer-rest-params)
+
+> IMPORTANCE: `...` is explicit about which arguments you want pulled.
+
+
+```js
+// bad 👎
+function concatenateAll() {
+  const args = Array.prototype.slice.call(arguments);
+  return args.join('');
+}
+
+// good 👍
+function concatenateAll(...args) {
+  return args.join('');
+}
+```
+
+
+### Use default parameter syntax rather than mutating function arguments.
+
+
+```js
+// really bad
+function handleThings(opts) {
+  // No! We shouldn't mutate function arguments.
+  // Double bad: if opts is falsy it'll be set to an object which may
+  // be what you want but it can introduce subtle bugs.
+  opts = opts || {};
+  // ...
+}
+
+// still bad
+function handleThings(opts) {
+  if (opts === void 0) {
+    opts = {};
+  }
+  // ...
+}
+
+// good 👍
+function handleThings(opts = {}) {
+  // ...
+}
+```
+
+
+### Avoid side effects with default parameters.
+
+> IMPORTANCE: They are confusing to reason about.
+
+
+```js
+var b = 1;
+// bad 👎
+function count(a = b++) {
+  console.log(a);
+}
+count(); // 1
+count(); // 2
+count(3); // 3
+count(); // 3
+```
+
+
+### Always put default parameters last.
+
+
+```js
+// bad 👎
+function handleThings(opts = {}, name) {
+  // ...
+}
+
+// good 👍
+function handleThings(name, opts = {}) {
+  // ...
+}
+```
+
+
+### Never use the Function constructor to create a new function.
+
+eslint: [`no-new-func`](https://eslint.org/docs/rules/no-new-func)
+
+> IMPORTANCE: Creating a function in this way evaluates a string similarly to `eval()`, which opens vulnerabilities.
+
+
+```js
+// bad 👎
+var add = new Function('a', 'b', 'return a + b');
+
+// still bad
+var subtract = Function('a', 'b', 'return a - b');
+```
+
+
+### Spacing in a function signature.
+
+eslint: [`space-before-function-paren`](https://eslint.org/docs/rules/space-before-function-paren) [`space-before-blocks`](https://eslint.org/docs/rules/space-before-blocks)
+
+> IMPORTANCE: Consistency is good, and you shouldn't have to add or remove a space when adding or removing a name.
+
+
+```js
+// bad 👎
+const f = function () {};
+const g = function () {};
+const h = function () {};
+
+// good 👍
+const x = function () {};
+const y = function a() {};
+```
+
+
+### Never mutate parameters.
+
+eslint: [`no-param-reassign`](https://eslint.org/docs/rules/no-param-reassign.html)
+
+> IMPORTANCE: Manipulating objects passed in as parameters can cause unwanted variable side effects in the original caller.
+
+
+```js
+// bad 👎
+function f1(obj) {
+  obj.key = 1;
+}
+
+// good 👍
+function f2(obj) {
+  const key = Object.prototype.hasOwnProperty.call(obj, 'key') ? obj.key : 1;
+}
+```
+
+
+### Never reassign parameters.
+
+eslint: [`no-param-reassign`](https://eslint.org/docs/rules/no-param-reassign.html)
+
+> IMPORTANCE: Reassigning parameters can lead to unexpected behavior, especially when accessing the `arguments` object. It can also cause optimization issues, especially in V8.
+
+
+```js
+// bad 👎
+function f1(a) {
+  a = 1;
+  // ...
+}
+
+function f2(a) {
+  if (!a) { a = 1; }
+  // ...
+}
+
+// good 👍
+function f3(a) {
+  const b = a || 1;
+  // ...
+}
+
+function f4(a = 1) {
+  // ...
+}
+```
+
+
+### Prefer the use of the spread operator `...` to call variadic functions.
+
+eslint: [`prefer-spread`](https://eslint.org/docs/rules/prefer-spread)
+
+> IMPORTANCE: It's cleaner, you don't need to supply a context, and you can not easily compose `new` with `apply`.
+
+
+```js
+// bad 👎
+const x = [1, 2, 3, 4, 5];
+console.log.apply(console, x);
+
+// good 👍
+const x = [1, 2, 3, 4, 5];
+console.log(...x);
+
+// bad 👎
+new (Function.prototype.bind.apply(Date, [null, 2016, 8, 5]))();
+
+// good 👍
+new Date(...[2016, 8, 5]);
+```
+
+
+### Functions with multiline signatures, or invocations, should be indented just like every other multiline.
+
+eslint: [`function-paren-newline`](https://eslint.org/docs/rules/function-paren-newline)
+
+
+```js
+// bad 👎
+function foo(bar,
+  			 baz,
+  			 quux) {
+  // ...
+}
+
+// good 👍
+function foo(
+  bar,
+  baz,
+  quux,
+) {
+  // ...
+}
+
+// bad 👎
+console.log(foo,
+  bar,
+  baz);
+
+// good 👍
+console.log(
+  foo,
+  bar,
+  baz,
+);
+```
+
+
+## Arrow Functions
+
+### When you must use an anonymous function (as when passing an inline callback), use arrow function notation.
+
+eslint: [`prefer-arrow-callback`](https://eslint.org/docs/rules/prefer-arrow-callback.html), [`arrow-spacing`](https://eslint.org/docs/rules/arrow-spacing.html)
+
+> IMPORTANCE: It creates a version of the function that executes in the context of `this`, which is usually what you want, and is a more concise syntax.
+
+> Why not? If you have a fairly complicated function, you might move that logic out into its own named function expression.
+
+
+```js
+// bad 👎
+[1, 2, 3].map(function (x) {
+  const y = x + 1;
+  return x * y;
+});
+
+// good 👍
+[1, 2, 3].map((x) => {
+  const y = x + 1;
+  return x * y;
+});
+```
+
+
+### If the function body consists of a single statement, omit the braces and use the implicit return. Otherwise, keep the braces and use a `return` statement.
+
+eslint: [`arrow-parens`](https://eslint.org/docs/rules/arrow-parens.html), [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style.html)
+
+> IMPORTANCE: It reads well when multiple functions are chained together.
+
+
+```js
+// bad 👎
+[1, 2, 3].map((number) => {
+  const nextNumber = number + 1;
+  `A string containing the ${nextNumber}.`;
+});
+
+// good 👍
+[1, 2, 3].map((number) => `A string containing the ${number + 1}.`);
+
+// good 👍
+[1, 2, 3].map((number) => {
+  const nextNumber = number + 1;
+  return `A string containing the ${nextNumber}.`;
+});
+
+// good 👍
+[1, 2, 3].map((number, index) => ({
+  [index]: number,
+}));
+
+// No implicit return with side effects
+function foo(callback) {
+  const val = callback();
+  if (val === true) {
+    // Do something if callback returns true
+  }
+}
+
+let bool = false;
+
+// bad 👎
+foo(() => (bool = true));
+
+// good 👍
+foo(() => {
+  bool = true;
+});
+```
+
+
+### In case the expression spans over multiple lines, wrap it in parentheses for better readability.
+
+> IMPORTANCE: It shows clearly where the function starts and ends.
+
+
+```js
+// bad 👎
+['get', 'post', 'put'].map((httpMethod) => Object.prototype.hasOwnProperty.call(
+    httpMagicObjectWithAVeryLongName,
+    httpMethod
+  )
+);
+
+// good 👍
+['get', 'post', 'put'].map((httpMethod) =>
+  Object.prototype.hasOwnProperty.call(
+    httpMagicObjectWithAVeryLongName,
+    httpMethod
+  )
+);
+```
+
+
+### Always include parentheses around arguments for clarity and consistency.
+
+eslint: [`arrow-parens`](https://eslint.org/docs/rules/arrow-parens.html)
+
+> IMPORTANCE: Minimizes diff churn when adding or removing arguments.
+
+
+```js
+// bad 👎
+[1, 2, 3].map(x => x * x);
+
+// good 👍
+[1, 2, 3].map((x) => x * x);
+
+// bad 👎
+[1, 2, 3].map(number => (
+    `A long string with the ${number}. It's so long that we don't want it to take up space on the .map line!`
+));
+
+// good 👍
+[1, 2, 3].map((number) => (
+    `A long string with the ${number}. It's so long that we don't want it to take up space on the .map line!`
+));
+
+// bad 👎
+[1, 2, 3].map(x => {
+  const y = x + 1;
+  return x * y;
+});
+
+// good 👍
+[1, 2, 3].map((x) => {
+  const y = x + 1;
+  return x * y;
+});
+```
+
+
+### Avoid confusing arrow function syntax (`=>`) with comparison operators (`<=`, `>=`).
+
+eslint: [`no-confusing-arrow`](https://eslint.org/docs/rules/no-confusing-arrow)
+
+
+```js
+// bad 👎
+const itemHeight = (item) => item.height <= 256 ? item.largeSize : item.smallSize;
+
+// bad 👎
+const itemHeight = (item) => item.height >= 256 ? item.largeSize : item.smallSize;
+
+// good 👍
+const itemHeight = (item) => (item.height <= 256 ? item.largeSize : item.smallSize);
+
+// good 👍
+const itemHeight = (item) => {
+  const { height, largeSize, smallSize } = item;
+  return height <= 256 ? largeSize : smallSize;
+};
+```
+
+
+### Enforce the location of arrow function bodies with implicit returns.
+
+eslint: [`implicit-arrow-linebreak`](https://eslint.org/docs/rules/implicit-arrow-linebreak)
+
+
+```js
+// bad 👎
+(foo) =>
+  bar;
+
+(foo) =>
+  (bar);
+
+// good 👍
+(foo) => bar;
+(foo) => (bar);
+(foo) => (
+  bar
+)
+```
+
+
+## Classes & Constructors
+
+### Always use `class`.
+
+> IMPORTANCE: `class` syntax is more concise and easier to reason about.
+
+
+```js
+// bad 👎
+function Queue(contents = []) {
+  this.queue = [...contents];
+}
+Queue.prototype.pop = function () {
+  const value = this.queue[0];
+  this.queue.splice(0, 1);
+  return value;
+};
+
+// good 👍
+class Queue {
+  constructor(contents = []) {
+    this.queue = [...contents];
+  }
+  pop() {
+    const value = this.queue[0];
+    this.queue.splice(0, 1);
+    return value;
+  }
+}
+```
+
+
+### Use `extends` for inheritance.
+
+> IMPORTANCE: It is a built-in way to inherit prototype functionality without breaking `instanceof`.
+
+
+```js
+// bad 👎
+const inherits = require('inherits');
+function PeekableQueue(contents) {
+  Queue.apply(this, contents);
+}
+inherits(PeekableQueue, Queue);
+PeekableQueue.prototype.peek = function () {
+  return this.queue[0];
+};
+
+// good 👍
+class PeekableQueue extends Queue {
+  peek() {
+    return this.queue[0];
+  }
+}
+```
+
+
+### Methods can return `this` to help with method chaining.
+
+
+```js
+// bad 👎
+Jedi.prototype.jump = function () {
+  this.jumping = true;
+  return true;
+};
+
+Jedi.prototype.setHeight = function (height) {
+  this.height = height;
+};
+
+const luke = new Jedi();
+luke.jump(); // => true
+luke.setHeight(20); // => undefined
+
+// good 👍
+class Jedi {
+  jump() {
+    this.jumping = true;
+    return this;
+  }
+
+  setHeight(height) {
+    this.height = height;
+    return this;
+  }
+}
+
+const luke = new Jedi();
+
+luke.jump()
+  .setHeight(20);
+```
+
+
+### It’s okay to write a custom `toString()` method, just make sure it works successfully and causes no side effects.
+
+```javascript
+class Jedi {
+  constructor(options = {}) {
+	this.name = options.name || 'no name';
+  }
+
+  getName() {
+	return this.name;
+  }
+
+  toString() {
+	return `Jedi - ${this.getName()}`;
+  }
+}
+```
+
+### Classes have a default constructor if one is not specified.
+
+An empty constructor function or one that just delegates to a parent class is unnecessary. eslint: [`no-useless-constructor`](https://eslint.org/docs/rules/no-useless-constructor)
+
+
+```js
+// bad 👎
+class Jedi {
+  constructor() {}
+
+  getName() {
+    return this.name;
+  }
+}
+
+// bad 👎
+class Rey extends Jedi {
+  constructor(...args) {
+    super(...args);
+  }
+}
+
+// good 👍
+class Rey extends Jedi {
+  constructor(...args) {
+    super(...args);
+    this.name = 'Rey';
+  }
+}
+```
+
+
+### Avoid duplicate class members.
+
+eslint: [`no-dupe-class-members`](https://eslint.org/docs/rules/no-dupe-class-members)
+
+> IMPORTANCE: Duplicate class member declarations will silently prefer the last one - having duplicates is almost certainly a bug.
+
+
+```js
+// bad 👎
+class Foo {
+  bar() { return 1; }
+  bar() { return 2; }
+}
+
+// good 👍
+class Foo {
+  bar() { return 1; }
+}
+
+// good 👍
+class Foo {
+  bar() { return 2; }
+}
+```
+
+
+### Class methods should use `this` or be made into a static method unless an external library or framework requires to use specific non-static methods.
+
+Being an instance method should indicate that it behaves differently based on properties of the receiver. eslint: [`class-methods-use-this`](https://eslint.org/docs/rules/class-methods-use-this)
+
+
+```js
+// bad 👎
+class Foo {
+  bar() {
+    console.log('bar');
+  }
+}
+
+// good 👍  - this is used
+class Foo {
+  bar() {
+    console.log(this.bar);
+  }
+}
+
+// good 👍  - constructor is exempt
+class Foo {
+  constructor() {
+    // ...
+  }
+}
+
+// good 👍  - static methods aren't expected to use this
+class Foo {
+  static bar() {
+    console.log('bar');
+  }
+}
+```
+
+
+## Modules
+
+### Always use modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
+
+> Why? Modules are the future, let’s start using the future now.
+
+```javascript
+// bad 👎
+const AirbnbStyleGuide = require('./AirbnbStyleGuide');
+module.exports = AirbnbStyleGuide.es6;
+
+// ok
+import AirbnbStyleGuide from './AirbnbStyleGuide';
+export default AirbnbStyleGuide.es6;
+
+// best
+import { es6 } from './AirbnbStyleGuide';
+export default es6;
+```
+
+### Do not use wildcard imports.
+
+> Why? This makes sure you have a single default export.
+
+```javascript
+// bad 👎
+import * as AirbnbStyleGuide from './AirbnbStyleGuide';
+
+// good 👍
+import AirbnbStyleGuide from './AirbnbStyleGuide';
+```
+
+### And do not export directly from an import.
+
+> Why? Although the one-liner is concise, having one clear way to import and one clear way to export makes things consistent.
+
+```javascript
+// bad 👎
+// filename es6.js
+export { es6 as default } from './AirbnbStyleGuide';
+
+// good 👍
+// filename es6.js
+import { es6 } from './AirbnbStyleGuide';
+export default es6;
+```
+
+### Only import from a path in one place.
+ eslint: [`no-duplicate-imports`](https://eslint.org/docs/rules/no-duplicate-imports)
+> Why? Having multiple lines that import from the same path can make code harder to maintain.
+
+```javascript
+// bad 👎
+import foo from 'foo';
+// … some other imports … //
+import { named1, named2 } from 'foo';
+
+// good 👍
+import foo, { named1, named2 } from 'foo';
+
+// good 👍
+import foo, {
+	named1,
+	named2,
+} from 'foo';
+```
+
+### Do not export mutable bindings.
+eslint: [`import/no-mutable-exports`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md)
+> Why? Mutation should be avoided in general, but in particular when exporting mutable bindings. While this technique may be needed for some special cases, in general, only constant references should be exported.
+
+```javascript
+// bad 👎
+let foo = 3;
+export { foo };
+
+// good 👍
+const foo = 3;
+export { foo };
+```
+
+### In modules with a single export, prefer default export over named export.
+eslint: [`import/prefer-default-export`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md)
+> Why? To encourage more files that only ever export one thing, which is better for readability and maintainability.
+
+```javascript
+// bad 👎
+export function foo() {}
+
+// good 👍
+export default function foo() {}
+```
+
+Put all `import`s above non-import statements.
+eslint: [`import/first`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md)
+> Why? Since `import`s are hoisted, keeping them all at the top prevents surprising behavior.
+
+```javascript
+// bad 👎
+import foo from 'foo';
+foo.init();
+
+import bar from 'bar';
+
+// good 👍
+import foo from 'foo';
+import bar from 'bar';
+
+foo.init();
+```
+
+### Multiline imports should be indented just like multiline array and object literals.
+eslint: [`object-curly-newline`](https://eslint.org/docs/rules/object-curly-newline)
+> Why? The curly braces follow the same indentation rules as every other curly brace block in the style guide, as do the trailing commas.
+
+```javascript
+// bad 👎
+import {longNameA, longNameB, longNameC, longNameD, longNameE} from 'path';
+
+// good 👍
+import {
+	longNameA,
+	longNameB,
+	longNameC,
+	longNameD,
+	longNameE,
+} from 'path';
+```
+
+### Disallow Webpack loader syntax in module import statements.
+eslint: [`import/no-webpack-loader-syntax`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md)
+> Why? Since using Webpack syntax in the imports couples the code to a module bundler. Prefer using the loader syntax in `webpack.config.js`.
+
+```javascript
+// bad 👎
+import fooSass from 'css!sass!foo.scss';
+import barCss from 'style!css!bar.css';
+
+// good 👍
+import fooSass from 'foo.scss';
+import barCss from 'bar.css';
+```
+
+### Do not include JavaScript filename extensions
+eslint: [`import/extensions`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md)
+> Why? Including extensions inhibits refactoring, and inappropriately hardcodes implementation details of the module you're importing in every consumer.
+
+```javascript
+// bad 👎
+import foo from './foo.js';
+import bar from './bar.jsx';
+import baz from './baz/index.jsx';
+
+// good 👍
+import foo from './foo';
+import bar from './bar';
+import baz from './baz';
+```
+## Iterators and Generators
+
+### Don't use iterators.
+
+Prefer JavaScript's higher-order functions instead of loops like `for-in` or `for-of`. eslint: [`no-iterator`](https://eslint.org/docs/rules/no-iterator.html) [`no-restricted-syntax`](https://eslint.org/docs/rules/no-restricted-syntax)
+
+> IMPORTANCE: This enforces our immutable rule. Dealing with pure functions that return values is easier to reason about than side effects.
+
+> Use `map()` / `every()` / `filter()` / `find()` / `findIndex()` / `reduce()` / `some()` / ... to iterate over arrays, and `Object.keys()` / `Object.values()` / `Object.entries()` to produce arrays so you can iterate over objects.
+
+
+```js
+const numbers = [1, 2, 3, 4, 5];
+
+// bad 👎
+let sum = 0;
+for (let num of numbers) {
+  sum += num;
+}
+sum === 15;
+
+// good 👍
+let sum = 0;
+numbers.forEach((num) => {
+  sum += num;
+});
+sum === 15;
+
+// best (use the functional force)
+const sum = numbers.reduce((total, num) => total + num, 0);
+sum === 15;
+
+// bad 👎
+const increasedByOne = [];
+for (let i = 0; i < numbers.length; i++) {
+  increasedByOne.push(numbers[i] + 1);
+}
+
+// good 👍
+const increasedByOne = [];
+numbers.forEach((num) => {
+  increasedByOne.push(num + 1);
+});
+
+// best (keeping it functional)
+const increasedByOne = numbers.map((num) => num + 1);
+```
+
+
+### Don’t use generators for now.
+> Why? They don’t transpile well to ES5.
+
+### If you must use generators, or if you disregard [our advice](#generators--nope), make sure their function signature is spaced properly.
+eslint: [`generator-star-spacing`](https://eslint.org/docs/rules/generator-star-spacing)
+> Why? `function` and `*` are part of the same conceptual keyword - `*` is not a modifier for `function`, `function*` is a unique construct, different from `function`.
+
+```javascript
+// bad 👎
+function * foo() {
+	// ...
+}
+
+// bad 👎
+const bar = function * () {
+	// ...
+};
+
+// bad 👎
+const baz = function *() {
+	// ...
+};
+
+// bad 👎
+const quux = function*() {
+	// ...
+};
+
+// bad 👎
+function*foo() {
+	// ...
+}
+
+// bad 👎
+function *foo() {
+	// ...
+}
+
+// very bad
+function
+*
+foo() {
+	// ...
+}
+
+// very bad
+const wat = function
+*
+() {
+	// ...
+};
+
+// good 👍
+function* foo() {
+	// ...
+}
+
+// good 👍
+const foo = function* () {
+	// ...
+};
+```
+## Properties
+
+### Use dot notation when accessing properties.
+eslint: [`dot-notation`](https://eslint.org/docs/rules/dot-notation.html)
+
+```javascript
+const luke = {
+  jedi: true,
+  age: 28,
+};
+
+// bad 👎
+const isJedi = luke['jedi'];
+
+// good 👍
+const isJedi = luke.jedi;
+```
+### Use bracket notation `[]` when accessing properties with a variable.
+
+```javascript
+const luke = {
+  jedi: true,
+  age: 28,
+};
+
+function getProp(prop) {
+  return luke[prop];
+}
+
+const isJedi = getProp('jedi');
+```
+
+### Use exponentiation operator `**` when calculating exponentiations.
+eslint: [`no-restricted-properties`](https://eslint.org/docs/rules/no-restricted-properties).
+
+```javascript
+// bad 👎
+const binary = Math.pow(2, 10);
+
+// good 👍
+const binary = 2 ** 10;
+```
+
+## Variables
+
+### Always use `const` or `let` to declare variables.
+
+'var' is a global variables. We want to avoid using the global namespace. eslint: [`no-undef`](https://eslint.org/docs/rules/no-undef) [`prefer-const`](https://eslint.org/docs/rules/prefer-const)
+
+
+```js
+// bad 👎
+superPower = new SuperPower();
+
+// good 👍
+const superPower = new SuperPower();
+```
+
+
+### Use one `const` or `let` declaration per variable or assignment.
+
+eslint: [`one-var`](https://eslint.org/docs/rules/one-var.html)
+
+> IMPORTANCE: It's easier to add new variable declarations this way, and you never have to worry about swapping out a `;` for a `,` or introducing punctuation-only diffs. You can also step through each declaration with the debugger, instead of jumping through all of them at once.
+
+
+```js
+// bad 👎
+const items = getItems(),
+  goSportsTeam = true,
+  dragonball = 'z';
+
+// bad 👎
+// (compare to above, and try to spot the mistake)
+const items = getItems(),
+  goSportsTeam = true;
+  dragonball = 'z';
+
+// good 👍
+const items = getItems();
+const goSportsTeam = true;
+const dragonball = 'z';
+```
+
+
+### Group all your `const` and then group all your `let`.
+
+This is helpful when later on you might need to assign a variable depending on one of the previous assigned variables.
+
+
+```js
+// bad 👎
+let i, len, dragonball,
+  items = getItems(),
+  goSportsTeam = true;
+
+// bad 👎
+let i;
+const items = getItems();
+let dragonball;
+const goSportsTeam = true;
+let len;
+
+// good 👍
+const goSportsTeam = true;
+const items = getItems();
+let dragonball;
+let i;
+let length;
+```
+
+
+### Assign variables where you need them, but place them in a reasonable place.
+
+`let` and `const` are block scoped and not function scoped.
+
+
+```js
+// bad 👎 - unnecessary function call
+function checkName(hasName) {
+  const name = getName();
+
+  if (hasName === 'test') {
+    return false;
+  }
+
+  if (name === 'test') {
+    this.setName('');
+    return false;
+  }
+
+  return name;
+}
+
+// good 👍
+function checkName(hasName) {
+  if (hasName === 'test') {
+    return false;
+  }
+
+  const name = getName();
+
+  if (name === 'test') {
+    this.setName('');
+    return false;
+  }
+
+  return name;
+}
+```
+
+
+### Don't chain variable assignments.
+
+eslint: [`no-multi-assign`](https://eslint.org/docs/rules/no-multi-assign)
+
+> Why? Chaining variable assignments creates implicit global variables.
+
+
+```js
+// bad 👎
+(function example() {
+  // JavaScript interprets this as
+  // let a = ( b = ( c = 1 ) );
+  // The let keyword only applies to variable a; variables b and c become
+  // global variables.
+  let a = (b = c = 1);
+}());
+
+console.log(a); // throws ReferenceError
+console.log(b); // 1
+console.log(c); // 1
+
+// good 👍
+(function example() {
+  let a = 1;
+  let b = a;
+  let c = a;
+}());
+
+console.log(a); // throws ReferenceError
+console.log(b); // throws ReferenceError
+console.log(c); // throws ReferenceError
+
+// the same applies for `const`
+```
+
+
+### Avoid using unary increments and decrements (`++`, `--`).
+eslint [`no-plusplus`](https://eslint.org/docs/rules/no-plusplus)
+> Why? Per the eslint documentation, unary increment and decrement statements are subject to automatic semicolon insertion and can cause silent errors with incrementing or decrementing values within an application. It is also more expressive to mutate your values with statements like `num += 1` instead of `num++` or `num ++`. Disallowing unary increment and decrement statements also prevents you from pre-incrementing/pre-decrementing values unintentionally which can also cause unexpected behavior in your programs.
+
+```javascript
+// bad 👎
+const array = [1, 2, 3];
+let num = 1;
+num++;
+--num;
+
+let sum = 0;
+let truthyCount = 0;
+for (let i = 0; i < array.length; i++) {
+  let value = array[i];
+  sum += value;
+  if (value) {
+	truthyCount++;
+  }
+}
+
+// good 👍
+const array = [1, 2, 3];
+let num = 1;
+num += 1;
+num -= 1;
+
+const sum = array.reduce((a, b) => a + b, 0);
+const truthyCount = array.filter(Boolean).length;
+```
+
+### Avoid linebreaks before or after `=` in an assignment.
+
+If your assignment violates [`max-len`](https://eslint.org/docs/rules/max-len.html), surround the value in parens. eslint [`operator-linebreak`](https://eslint.org/docs/rules/operator-linebreak.html).
+
+Linebreaks surrounding `=` can obfuscate the value of an assignment.
+
+
+```js
+// bad 👎
+const foo =
+  superLongLongLongLongLongLongLongLongFunctionName();
+
+// bad 👎
+const foo
+  = 'superLongLongLongLongLongLongLongLongString';
+
+// good 👍
+const foo = (
+  superLongLongLongLongLongLongLongLongFunctionName();
+);
+
+// good 👍
+const foo = 'superLongLongLongLongLongLongLongLongString';
+```
+
+
+### Disallow unused variables.
+
+eslint: [`no-unused-vars`](https://eslint.org/docs/rules/no-unused-vars)
+
+> Why? Variables that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring. Such variables take up space in the code and can lead to confusion by readers.
+
+
+```js
+// bad 👎
+var some_unused_var = 42;
+
+// Write-only variables are not considered as used.
+var y = 10;
+y = 5;
+
+// A read for a modification of itself is not considered as used.
+var z = 0;
+z = z + 1;
+
+// Unused function arguments.
+function getX(x, y) {
+  return x;
+}
+
+// good 👍
+function getXPlusY(x, y) {
+  return x + y;
+}
+
+var x = 1;
+var y = a + 2;
+
+alert(getXPlusY(x, y));
+
+// 'type' is ignored even if unused because it has a rest property sibling.
+// This is a form of extracting an object that omits the specified keys.
+var { type, ...coords } = data;
+// 'coords' is now the 'data' object without its 'type' property.
+```
+
+
+### Object / Array creation
+
+Use trailing commas and put short declarations on a single line.
+
+
+```js
+// bad 👎
+var a = [
+  'hello', 'world'
+];
+var b = {'good': 'code'
+        , is generally: 'pretty'
+        };
+
+// good 👍
+var a = ['hello', 'world'];
+var b = {
+  good: 'code',
+  'is generally': 'pretty',
+};
+```
+
+
+## Hoisting
+
+
+### `var` declarations get hoisted to the top of their closest enclosing function scope, their assignment does not.
+> `const` and `let` declarations are blessed with a new concept called [Temporal Dead Zones (TDZ)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#Temporal_dead_zone). It’s important to know why [typeof is no longer safe](http://es-discourse.com/t/why-typeof-is-no-longer-safe/15).
+
+```javascript
+// we know this wouldn’t work (assuming there
+// is no notDefined global variable)
+function example() {
+  console.log(notDefined); // => throws a ReferenceError
+}
+
+// creating a variable declaration after you
+// reference the variable will work due to
+// variable hoisting. Note: the assignment
+// value of `true` is not hoisted.
+function example() {
+  console.log(declaredButNotAssigned); // => undefined
+  var declaredButNotAssigned = true;
+}
+
+// the interpreter is hoisting the variable
+// declaration to the top of the scope,
+// which means our example could be rewritten as:
+function example() {
+  let declaredButNotAssigned;
+  console.log(declaredButNotAssigned); // => undefined
+  declaredButNotAssigned = true;
+}
+
+// using const and let
+function example() {
+  console.log(declaredButNotAssigned); // => throws a ReferenceError
+  console.log(typeof declaredButNotAssigned); // => throws a ReferenceError
+  const declaredButNotAssigned = true;
+}
+```
+
+### Anonymous function expressions hoist their variable name, but not the function assignment.
+
+```javascript
+function example() {
+  console.log(anonymous); // => undefined
+
+  anonymous(); // => TypeError anonymous is not a function
+
+  var anonymous = function () {
+	console.log('anonymous function expression');
+  };
+}
+```
+
+
+### Named function expressions hoist the variable name, not the function name or the function body.
+
+```javascript
+function example() {
+  console.log(named); // => undefined
+
+  named(); // => TypeError named is not a function
+
+  superPower(); // => ReferenceError superPower is not defined
+
+  var named = function superPower() {
+	console.log('Flying');
+  };
+}
+
+// the same is true when the function name
+// is the same as the variable name.
+function example() {
+  console.log(named); // => undefined
+
+  named(); // => TypeError named is not a function
+
+  var named = function named() {
+	console.log('named');
+  };
+}
+```
+
+### Function declarations hoist their name and the function body.
+
+```javascript
+function example() {
+  superPower(); // => Flying
+
+  function superPower() {
+	console.log('Flying');
+  }
+}
+```
+
+> For more information refer to [JavaScript Scoping & Hoisting](http://www.adequatelygood.com/2010/2/JavaScript-Scoping-and-Hoisting/) by [Ben Cherry](http://www.adequatelygood.com/).
+
+## Comparison Operators & Equality
+
+### Must use `===` and `!==` over `==` and `!=`.
+
+eslint: [`eqeqeq`](https://eslint.org/docs/rules/eqeqeq.html)
+
+### Conditional statements such as the `if` statement evaluate their expression using coercion with the `ToBoolean` abstract method and always follow these simple rules:
+
+- **Objects** evaluate to **true**
+- **Undefined** evaluates to **false**
+- **Null** evaluates to **false**
+- **Booleans** evaluate to **the value of the boolean**
+- **Numbers** evaluate to **false** if **+0, -0, or NaN**, otherwise **true**
+- **Strings** evaluate to **false** if an empty string `''`, otherwise **true**
+
+
+```js
+if ([0] && []) {
+  // true
+  // an array (even an empty one) is an object, objects will evaluate to true
+}
+```
+
+
+### Use shortcuts for booleans, but explicit comparisons for strings and numbers.
+
+
+```js
+// bad 👎
+if (isValid === true) {
+  // ...
+}
+
+// good 👍
+if (isValid) {
+  // ...
+}
+
+// bad 👎
+if (name) {
+  // ...
+}
+
+// good 👍
+if (name !== '') {
+  // ...
+}
+
+// bad 👎
+if (collection.length) {
+  // ...
+}
+
+// good 👍
+if (collection.length > 0) {
+  // ...
+}
+```
+
+
+### For more information see [Truth Equality and JavaScript](https://javascriptweblog.wordpress.com/2011/02/07/truth-equality-and-javascript/#more-2108) by Angus Croll.
+
+### Use braces to create blocks in `case` and `default` clauses that contain lexical declarations (e.g. `let`, `const`, `function`, and `class`).
+eslint: [`no-case-declarations`](https://eslint.org/docs/rules/no-case-declarations.html)
+> Why? Lexical declarations are visible in the entire `switch` block but only get initialized when assigned, which only happens when its `case` is reached. This causes problems when multiple `case` clauses attempt to define the same thing.
+
+```javascript
+// bad 👎
+switch (foo) {
+  case 1:
+	let x = 1;
+	break;
+  case 2:
+	const y = 2;
+	break;
+  case 3:
+	function f() {
+		// ...
+	}
+	break;
+  default:
+	class C {}
+}
+
+// good 👍
+switch (foo) {
+  case 1: {
+	let x = 1;
+	break;
+  }
+  case 2: {
+	const y = 2;
+	break;
+  }
+  case 3: {
+	function f() {
+		// ...
+    }
+    break;
+  }
+  case 4:
+	bar();
+	break;
+  default: {
+	class C {}
+  }
+}
+```
+
+### Ternaries should not be nested and generally be single line expressions.
+eslint: [`no-nested-ternary`](https://eslint.org/docs/rules/no-nested-ternary.html)
+
+
+```js
+// bad 👎
+const foo = maybe1 > maybe2
+  ? 'bar'
+  : value1 > value2 ? 'baz' : null;
+
+// split into 2 separated ternary expressions
+const maybeNull = value1 > value2 ? 'baz' : null;
+
+// better
+const foo = maybe1 > maybe2
+  ? 'bar'
+  : maybeNull;
+
+// best
+const foo = maybe1 > maybe2 ? 'bar' : maybeNull;
+```
+
+
+### Avoid unneeded ternary statements.
+eslint: [`no-unneeded-ternary`](https://eslint.org/docs/rules/no-unneeded-ternary.html)
+
+
+```js
+// bad 👎
+const foo = a ? a : b;
+const bar = c ? true : false;
+const baz = c ? false : true;
+
+// good 👍
+const foo = a || b;
+const bar = !!c;
+const baz = !c;
+```
+
+
+### When mixing operators, enclose them in parentheses.
+
+The only exception is the standard arithmetic operators: `+`, `-`, and `**` since their precedence is broadly understood. We recommend enclosing `/` and `*` in parentheses because their precedence can be ambiguous when they are mixed.
+eslint: [`no-mixed-operators`](https://eslint.org/docs/rules/no-mixed-operators.html)
+
+> IMPORTANCE: This improves readability and clarifies the developer's intention.
+
+
+```js
+// bad 👎
+const foo = a && b < 0 || c > 0 || d + 1 === 0;
+
+// bad 👎
+const bar = a ** b - 5 % d;
+
+// bad 👎
+// one may be confused into thinking (a || b) && c
+if (a || b && c) {
+  return d;
+}
+
+// bad 👎
+const bar = a + b / c * d;
+
+// good 👍
+const foo = (a && b < 0) || c > 0 || (d + 1 === 0);
+
+// good 👍
+const bar = a ** b - (5 % d);
+
+// good 👍
+if (a || (b && c)) {
+  return d;
+}
+
+// good 👍
+const bar = a + (b / c) * d;
+```
+
+
+## Blocks
+
+### Use braces with all multiline blocks.
+
+eslint: [`nonblock-statement-body-position`](https://eslint.org/docs/rules/nonblock-statement-body-position)
+
+
+```js
+// bad 👎
+if (test)
+  return false;
+
+// good 👍
+if (test) return false;
+
+// good 👍
+if (test) {
+  return false;
+}
+
+// bad 👎
+function foo() { return false; }
+
+// good 👍
+function bar() {
+  return false;
+}
+```
+
+
+### If you're using multiline blocks with `if` and `else`, put `else` on the same line. as your `if` block's closing brace.
+
+eslint: [`brace-style`](https://eslint.org/docs/rules/brace-style.html)
+
+
+```js
+// bad 👎
+if (test) {
+  thing1();
+  thing2();
+} else {
+  thing3();
+}
+
+// good 👍
+if (test) {
+  thing1();
+  thing2();
+} else {
+  thing3();
+}
+```
+
+
+### If an `if` block always executes a `return` statement, the subsequent `else` block is unnecessary.
+
+A `return` in an `else if` block following an `if` block that contains a `return` can be separated into multiple `if` blocks. eslint: [`no-else-return`](https://eslint.org/docs/rules/no-else-return)
+
+
+```js
+// bad 👎
+function foo() {
+  if (x) {
+    return x;
+  } else {
+    return y;
+  }
+}
+
+// bad 👎
+function cats() {
+  if (x) {
+    return x;
+  } else if (y) {
+    return y;
+  }
+}
+
+// bad 👎
+function dogs() {
+  if (x) {
+    return x;
+  } else {
+    if (y) {
+      return y;
+    }
+  }
+}
+
+// good 👍
+function foo() {
+  if (x) {
+    return x;
+  }
+
+  return y;
+}
+
+// good 👍
+function cats() {
+  if (x) {
+    return x;
+  }
+
+  if (y) {
+    return y;
+  }
+}
+
+// good 👍
+function dogs(x) {
+  if (x) {
+    if (z) {
+      return y;
+    }
+  } else {
+    return z;
+  }
+}
+```
+
+
+## Control Statements
+
+### In case your control statement (`if`, `while` etc.) gets too long or exceeds the maximum line length, each (grouped) condition could be put into a new line. The logical operator should begin the line.
+
+> IMPORTANCE: This also improves readability by making it easier to visually follow complex logic.
+
+
+```js
+// bad 👎
+if ((foo === 123 || bar === 'abc') && doesItLookGoodWhenItBecomesThatLong() && isThisReallyHappening()) {
+  thing1();
+}
+
+// bad 👎
+if (foo === 123 &&
+  bar === 'abc') {
+  thing1();
+}
+
+// bad 👎
+if (foo === 123
+  && bar === 'abc') {
+  thing1();
+}
+
+// bad 👎
+if (
+  foo === 123 &&
+  bar === 'abc'
+) {
+  thing1();
+}
+
+// good 👍
+if (
+	foo === 123
+	&& bar === 'abc'
+) {
+  thing1();
+}
+
+// good 👍
+if (
+  (foo === 123 || bar === 'abc')
+  && doesItLookGoodWhenItBecomesThatLong()
+  && isThisReallyHappening()
+) {
+  thing1();
+}
+
+// good 👍
+if (foo === 123 && bar === 'abc') {
+  thing1();
+}
+```
+
+
+### Don't use selection operators in place of control statements.
+
+
+```js
+// bad 👎
+!isRunning && startRunning();
+
+// good 👍
+if (!isRunning) {
+  startRunning();
+}
+```
+
+
+## Comments
+
+### Use `/** ... */` for multiline comments.
+
+
+```js
+// bad 👎
+// make() returns a new element
+// based on the passed in tag name
+//
+// @param {String} tag
+// @return {Element} element
+function make(tag) {
+  // ...
+
+  return element;
+}
+
+// good 👍
+/**
+ * make() returns a new element
+ * based on the passed-in tag name
+ */
+function make(tag) {
+  // ...
+
+  return element;
+}
+```
+
+
+### Use `//` for single line comments.
+
+Place single line comments on a newline above the subject of the comment. Put an empty line before the comment unless it's on the first line of a block.
+
+
+```js
+// bad 👎
+const active = true; // is current tab
+
+// good 👍
+// is current tab
+const active = true;
+
+// bad 👎
+function getType() {
+  console.log('fetching type...');
+  // set the default type to 'no type'
+  const type = this.type || 'no type';
+
+  return type;
+}
+
+// good 👍
+function getType() {
+  console.log('fetching type...');
+
+  // set the default type to 'no type'
+  const type = this.type || 'no type';
+
+  return type;
+}
+
+// also good
+function getType() {
+  // set the default type to 'no type'
+  const type = this.type || 'no type';
+
+  return type;
+}
+```
+
+
+### Start all comments with a space to make it easier to read.
+
+eslint: [`spaced-comment`](https://eslint.org/docs/rules/spaced-comment)
+
+
+```js
+// bad 👎
+//is current tab
+const active = true;
+
+// good 👍
+// is current tab
+const active = true;
+
+// bad 👎
+/**
+ *make() returns a new element
+ *based on the passed-in tag name
+ */
+function make(tag) {
+  // ...
+
+  return element;
+}
+
+// good 👍
+/**
+ * make() returns a new element
+ * based on the passed-in tag name
+ */
+function make(tag) {
+  // ...
+
+  return element;
+}
+```
+
+
+### Prefixing your comments with `FIXME` or `TODO` helps other developers quickly understand.
+
+#### Use `// FIXME:` to annotate problems.
+
+
+```js
+class Calculator extends Abacus {
+  constructor() {
+    super();
+
+    // FIXME: shouldn't use a global here
+    total = 0;
+  }
+}
+```
+
+
+#### Use `// TODO:` to annotate solutions to problems.
+
+
+```js
+class Calculator extends Abacus {
+  constructor() {
+    super();
+
+    // TODO: total should be configurable by an options param
+    this.total = 0;
+  }
+}
+```
+
+
+## Commas
+### Leading commas: **Nope.**
+eslint: [`comma-style`](https://eslint.org/docs/rules/comma-style.html)
+
+```javascript
+// bad 👎
+const story = [
+  once
+  , upon
+  , aTime
+];
+
+// good 👍
+const story = [
+  once,
+  upon,
+  aTime,
+];
+
+// bad 👎
+const hero = {
+  firstName: 'Ada'
+  , lastName: 'Lovelace'
+  , birthYear: 1815
+  , superPower: 'computers'
+};
+
+// good 👍
+const hero = {
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  birthYear: 1815,
+  superPower: 'computers',
+};
+```
+
+### Additional trailing comma: **Yup.**
+eslint: [`comma-dangle`](https://eslint.org/docs/rules/comma-dangle.html)
+> Why? This leads to cleaner git diffs. Also, transpilers like Babel will remove the additional trailing comma in the transpiled code which means you don’t have to worry about the [trailing comma problem](https://github.com/airbnb/javascript/blob/es5-deprecated/es5/README.md#commas) in legacy browsers.
+
+```diff
+// bad 👎 - git diff without trailing comma
+const hero = {
+		firstName: 'Florence',
+-    lastName: 'Nightingale'
++    lastName: 'Nightingale',
++    inventorOf: ['coxcomb chart', 'modern nursing']
+};
+
+// good 👍  - git diff with trailing comma
+const hero = {
+		firstName: 'Florence',
+		lastName: 'Nightingale',
++    inventorOf: ['coxcomb chart', 'modern nursing'],
+};
+```
+
+```javascript
+// bad 👎
+const hero = {
+  firstName: 'Dana',
+  lastName: 'Scully'
+};
+
+const heroes = [
+  'Batman',
+  'Superman'
+];
+
+// good 👍
+const hero = {
+  firstName: 'Dana',
+  lastName: 'Scully',
+};
+
+const heroes = [
+  'Batman',
+  'Superman',
+];
+
+// bad 👎
+function createHero(
+  firstName,
+  lastName,
+  inventorOf
+) {
+	// does nothing
+}
+
+// good 👍
+function createHero(
+  firstName,
+  lastName,
+  inventorOf,
+) {
+	// does nothing
+}
+
+// good 👍  (note that a comma must not appear after a "rest" element)
+function createHero(
+  firstName,
+  lastName,
+  inventorOf,
+  ...heroArgs
+) {
+	// does nothing
+}
+
+// bad 👎
+createHero(
+  firstName,
+  lastName,
+  inventorOf
+);
+
+// good 👍
+createHero(
+  firstName,
+  lastName,
+  inventorOf,
+);
+
+// good 👍  (note that a comma must not appear after a "rest" element)
+createHero(
+  firstName,
+  lastName,
+  inventorOf,
+  ...heroArgs
+);
+```
+
+## Semicolons
+
+### **Yup.**
+eslint: [`semi`](https://eslint.org/docs/rules/semi.html)
+> Why? When JavaScript encounters a line break without a semicolon, it uses a set of rules called [Automatic Semicolon Insertion](https://tc39.github.io/ecma262/#sec-automatic-semicolon-insertion) to determine whether or not it should regard that line break as the end of a statement, and (as the name implies) place a semicolon into your code before the line break if it thinks so. ASI contains a few eccentric behaviors, though, and your code will break if JavaScript misinterprets your line break. These rules will become more complicated as new features become a part of JavaScript. Explicitly terminating your statements and configuring your linter to catch missing semicolons will help prevent you from encountering issues.
+
+```javascript
+// bad 👎 - raises exception
+const luke = {}
+const leia = {}
+[luke, leia].forEach((jedi) => jedi.father = 'vader')
+
+// bad 👎 - raises exception
+const reaction = "No! That’s impossible!"
+(async function meanwhileOnTheFalcon() {
+	// handle `leia`, `lando`, `chewie`, `r2`, `c3p0`
+	// ...
+}())
+
+// bad 👎 - returns `undefined` instead of the value on the next line - always happens when `return` is on a line by itself because of ASI!
+function foo() {
+	return
+	'search your feelings, you know it to be foo'
+}
+
+// good 👍
+const luke = {};
+const leia = {};
+[luke, leia].forEach((jedi) => {
+	jedi.father = 'vader';
+});
+
+// good 👍
+const reaction = "No! That’s impossible!";
+(async function meanwhileOnTheFalcon() {
+	// handle `leia`, `lando`, `chewie`, `r2`, `c3p0`
+	// ...
+}());
+
+// good 👍
+function foo() {
+	return 'search your feelings, you know it to be foo';
+}
+```
+
+## Type Casting & Coercion
+
+### Perform type coercion at the beginning of the statement.
+
+### Strings
+eslint: [`no-new-wrappers`](https://eslint.org/docs/rules/no-new-wrappers)
+
+```javascript
+// => this.reviewScore = 9;
+
+// bad 👎
+const totalScore = new String(this.reviewScore); // typeof totalScore is "object" not "string"
+
+// bad 👎
+const totalScore = this.reviewScore + ''; // invokes this.reviewScore.valueOf()
+
+// bad 👎
+const totalScore = this.reviewScore.toString(); // isn’t guaranteed to return a string
+
+// good 👍
+const totalScore = String(this.reviewScore);
+```
+
+### Numbers: Use `Number` for type casting and `parseInt` always with a radix for parsing strings.
+eslint: [`radix`](https://eslint.org/docs/rules/radix) [`no-new-wrappers`](https://eslint.org/docs/rules/no-new-wrappers)
+
+```javascript
+const inputValue = '4';
+
+// bad 👎
+const val = new Number(inputValue);
+
+// bad 👎
+const val = +inputValue;
+
+// bad 👎
+const val = inputValue >> 0;
+
+// bad 👎
+const val = parseInt(inputValue);
+
+// good 👍
+const val = Number(inputValue);
+
+// good 👍
+const val = parseInt(inputValue, 10);
+```
+
+### If for whatever reason you are doing something wild and `parseInt` is your bottleneck and need to use Bitshift for [performance reasons](https://jsperf.com/coercion-vs-casting/3), leave a comment explaining why and what you’re doing.
+
+```javascript
+// good 👍
+/**
+ * parseInt was the reason my code was slow.
+ * Bitshifting the String to coerce it to a
+ * Number made it a lot faster.
+ */
+const val = inputValue >> 0;
+```
+
+### **Note:** Be careful when using bitshift operations. Numbers are represented as [64-bit values](https://es5.github.io/#x4.3.19), but bitshift operations always return a 32-bit integer ([source](https://es5.github.io/#x11.7)). Bitshift can lead to unexpected behavior for integer values larger than 32 bits. [Discussion](https://github.com/airbnb/javascript/issues/109). Largest signed 32-bit Int is 2,147,483,647:
+
+```javascript
+2147483647 >> 0; // => 2147483647
+2147483648 >> 0; // => -2147483648
+2147483649 >> 0; // => -2147483647
+```
+
+### Booleans
+eslint: [`no-new-wrappers`](https://eslint.org/docs/rules/no-new-wrappers)
+
+```javascript
+const age = 0;
+
+// bad 👎
+const hasAge = new Boolean(age);
+
+// good 👍
+const hasAge = Boolean(age);
+
+// best
+const hasAge = !!age;
+```
+
+## Naming Conventions
+
+### Avoid single letter names. Be descriptive with your naming.
+eslint: [`id-length`](https://eslint.org/docs/rules/id-length)
+
+```javascript
+// bad 👎
+function q() {
+	// ...
+}
+
+// good 👍
+function query() {
+	// ...
+}
+```
+
+### Use camelCase when naming objects, functions, and instances.
+eslint: [`camelcase`](https://eslint.org/docs/rules/camelcase.html)
+
+```javascript
+// bad 👎
+const OBJEcttsssss = {};
+const this_is_my_object = {};
+function c() {}
+
+// good 👍
+const thisIsMyObject = {};
+function thisIsMyFunction() {}
+```
+
+### Use PascalCase only when naming constructors or classes.
+eslint: [`new-cap`](https://eslint.org/docs/rules/new-cap.html)
+
+```javascript
+// bad 👎
+function user(options) {
+	this.name = options.name;
+}
+
+const bad = new user({
+	name: 'nope',
+});
+
+// good 👍
+class User {
+  constructor(options) {
+	this.name = options.name;
+  }
+}
+
+const good = new User({
+  name: 'yup',
+});
+```
+
+### Do not use trailing or leading underscores.
+eslint: [`no-underscore-dangle`](https://eslint.org/docs/rules/no-underscore-dangle.html)
+> Why? JavaScript does not have the concept of privacy in terms of properties or methods. Although a leading underscore is a common convention to mean “private”, in fact, these properties are fully public, and as such, are part of your public API contract. This convention might lead developers to wrongly think that a change won’t count as breaking, or that tests aren’t needed. tl;dr: if you want something to be “private”, it must not be observably present.
+
+```javascript
+// bad 👎
+this.__firstName__ = 'Panda';
+this.firstName_ = 'Panda';
+this._firstName = 'Panda';
+
+// good 👍
+this.firstName = 'Panda';
+
+// good 👍 , in environments where WeakMaps are available
+// see https://kangax.github.io/compat-table/es6/#test-WeakMap
+const firstNames = new WeakMap();
+firstNames.set(this, 'Panda');
+```
+
+
+### Don’t save references to `this`. Use arrow functions or [Function#bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind).
+
+```javascript
+// bad 👎
+function foo() {
+  const self = this;
+  return function () {
+	console.log(self);
+  };
+}
+
+// bad 👎
+function foo() {
+  const that = this;
+  return function () {
+	console.log(that);
+  };
+}
+
+// good 👍
+function foo() {
+  return () => {
+	console.log(this);
+  };
+}
+```
+
+### A base filename should exactly match the name of its default export.
+
+```javascript
+// file 1 contents
+class CheckBox {
+	// ...
+}
+export default CheckBox;
+
+// file 2 contents
+export default function fortyTwo() { return 42; }
+
+// file 3 contents
+export default function insideDirectory() {}
+
+// in some other file
+// bad 👎
+import CheckBox from './checkBox'; // PascalCase import/export, camelCase filename
+import FortyTwo from './FortyTwo'; // PascalCase import/filename, camelCase export
+import InsideDirectory from './InsideDirectory'; // PascalCase import/filename, camelCase export
+
+// bad 👎
+import CheckBox from './check_box'; // PascalCase import/export, snake_case filename
+import forty_two from './forty_two'; // snake_case import/filename, camelCase export
+import inside_directory from './inside_directory'; // snake_case import, camelCase export
+import index from './inside_directory/index'; // requiring the index file explicitly
+import insideDirectory from './insideDirectory/index'; // requiring the index file explicitly
+
+// good 👍
+import CheckBox from './CheckBox'; // PascalCase export/import/filename
+import fortyTwo from './fortyTwo'; // camelCase export/import/filename
+import insideDirectory from './insideDirectory'; // camelCase export/import/directory name/implicit "index"
+// ^ supports both insideDirectory.js and insideDirectory/index.js
+```
+### Use camelCase when you export-default a function. Your filename should be identical to your function’s name.
+
+```javascript
+function makeStyleGuide() {
+	// ...
+}
+
+export default makeStyleGuide;
+```
+
+### Use PascalCase when you export a constructor / class / singleton / function library / bare object.
+
+```javascript
+const AirbnbStyleGuide = {
+  es6: {
+  },
+};
+
+export default AirbnbStyleGuide;
+```
+
+
+### Acronyms and initialisms should always be all uppercased, or all lowercased.
+> Why? Names are for readability, not to appease a computer algorithm.
+
+```javascript
+// bad 👎
+import SmsContainer from './containers/SmsContainer';
+
+// bad 👎
+const HttpRequests = [
+	// ...
+];
+
+// good 👍
+import SMSContainer from './containers/SMSContainer';
+
+// good 👍
+const HTTPRequests = [
+	// ...
+];
+
+// also good
+const httpRequests = [
+	// ...
+];
+
+// best
+import TextMessageContainer from './containers/TextMessageContainer';
+
+// best
+const requests = [
+	// ...
+];
+```
+
+### You may optionally uppercase a constant only if it (1) is exported, (2) is a `const` (it can not be reassigned), and (3) the programmer can trust it (and its nested properties) to never change.
+
+> Why? This is an additional tool to assist in situations where the programmer would be unsure if a variable might ever change. UPPERCASE_VARIABLES are letting the programmer know that they can trust the variable (and its properties) not to change.
+- What about all `const` variables? - This is unnecessary, so uppercasing should not be used for constants within a file. It should be used for exported constants however.
+- What about exported objects? - Uppercase at the top level of export (e.g. `EXPORTED_OBJECT.key`) and maintain that all nested properties do not change.
+
+```javascript
+// bad 👎
+const PRIVATE_VARIABLE = 'should not be unnecessarily uppercased within a file';
+
+// bad 👎
+export const THING_TO_BE_CHANGED = 'should obviously not be uppercased';
+
+// bad 👎
+export let REASSIGNABLE_VARIABLE = 'do not use let with uppercase variables';
+
+// ---
+
+// allowed but does not supply semantic value
+export const apiKey = 'SOMEKEY';
+
+// better in most cases
+export const API_KEY = 'SOMEKEY';
+
+// ---
+
+// bad 👎 - unnecessarily uppercases key while adding no semantic value
+export const MAPPING = {
+	KEY: 'value'
+};
+
+// good 👍
+export const MAPPING = {
+	key: 'value'
+};
+```
+
+### Use UPPERCASE for Constants
+
+Constants should be declared as regular variables or static class properties, using all uppercase letters.
+
+
+```js
+// bad 👎
+const second = 1 * 1000;
+function File() {
+}
+File.fullPermissions = 0777;
+
+// good 👍
+var SECOND = 1 * 1000;
+function File() {
+}
+File.FULL_PERMISSIONS = 0777;
+```
+
+
+### Use camelCase for variables, properties and function names
+
+Variables, properties and function names should use camelCase. They should also be descriptive. Single character variables and uncommon abbreviations should generally be avoided.
+
+
+```js
+// bad 👎
+var admin_user = db.query('SELECT * FROM users ...');
+
+// good 👍
+var adminUser = db.query('SELECT * FROM users ...');
+```
+
+
+## Accessors
+
+### Accessor functions for properties are not required.
+
+### Do not use JavaScript getters/setters as they cause unexpected side effects and are harder to test, maintain, and reason about. Instead, if you do make accessor functions, use `getVal()` and `setVal('hello')`.
+
+```javascript
+// bad 👎
+class Dragon {
+	get age() {
+	// ...
+	}
+
+	set age(value) {
+	// ...
+	}
+}
+
+// good 👍
+class Dragon {
+	getAge() {
+	// ...
+	}
+
+	setAge(value) {
+	// ...
+	}
+}
+```
+
+### If the property/method is a `boolean`, use `isVal()` or `hasVal()`.
+
+```javascript
+// bad 👎
+if (!dragon.age()) {
+	return false;
+}
+
+// good 👍
+if (!dragon.hasAge()) {
+	return false;
+}
+```
+
+It’s okay to create `get()` and `set()` functions, but be consistent.
+
+```javascript
+class Jedi {
+  constructor(options = {}) {
+  const lightsaber = options.lightsaber || 'blue';
+	this.set('lightsaber', lightsaber);
+  }
+
+  set(key, val) {
+	this[key] = val;
+  }
+
+  get(key) {
+	return this[key];
+  }
+}
+```
+
+## Events
+
+### When attaching data payloads to events (whether DOM events or something more proprietary like Backbone events), pass an object literal (also known as a "hash") instead of a raw value. This allows a subsequent contributor to add more data to the event payload without finding and updating every handler for the event. For example, instead of:
+
+```javascript
+// bad 👎
+$(this).trigger('listingUpdated', listing.id);
+
+// ...
+
+$(this).on('listingUpdated', (e, listingID) => {
+	// do something with listingID
+});
+```
+
+prefer:
+
+```javascript
+// good 👍
+$(this).trigger('listingUpdated', { listingID: listing.id });
+
+// ...
+
+$(this).on('listingUpdated', (e, data) => {
+	// do something with data.listingID
+});
+```
+
+## jQuery
+
+### Prefix jQuery object variables with a `$`.
+
+```javascript
+// bad 👎
+const sidebar = $('.sidebar');
+
+// good 👍
+const $sidebar = $('.sidebar');
+
+// good 👍
+const $sidebarBtn = $('.sidebar-btn');
+```
+
+### Cache jQuery lookups.
+
+```javascript
+// bad 👎
+function setSidebar() {
+  $('.sidebar').hide();
+
+  // ...
+
+  $('.sidebar').css({
+	'background-color': 'pink',
+  });
+}
+
+// good 👍
+function setSidebar() {
+  const $sidebar = $('.sidebar');
+  $sidebar.hide();
+
+  // ...
+
+  $sidebar.css({
+	'background-color': 'pink',
+  });
+}
+```
+
+### For DOM queries use Cascading `$('.sidebar ul')` or parent > child `$('.sidebar > ul')`.
+Performance Testing Link - [jsPerf](http://jsperf.com/jquery-find-vs-context-sel/16)
+
+### Use `find` with scoped jQuery object queries.
+
+```javascript
+// bad 👎
+$('ul', '.sidebar').hide();
+
+// bad 👎
+$('.sidebar').find('ul').hide();
+
+// good 👍
+$('.sidebar ul').hide();
+
+// good 👍
+$('.sidebar > ul').hide();
+
+// good 👍
+$sidebar.find('ul').hide();
+```
+
+## ECMAScript 5 Compatibility
+
+### Refer to [Kangax](https://twitter.com/kangax/)’s ES5 [compatibility table](https://kangax.github.io/es5-compat-table/).
+
+
+## ECMAScript 6+ (ES 2015+) Styles
+
+### This is a collection of links to the various ES6+ features.
+
+1. [Arrow Functions](#arrow-functions)
+1. [Classes](#classes--constructors)
+1. [Object Shorthand](#es6-object-shorthand)
+1. [Object Concise](#es6-object-concise)
+1. [Object Computed Properties](#es6-computed-properties)
+1. [Template Strings](#es6-template-literals)
+1. [Destructuring](#destructuring)
+1. [Default Parameters](#es6-default-parameters)
+1. [Rest](#es6-rest)
+1. [Array Spreads](#es6-array-spreads)
+1. [Let and Const](#references)
+1. [Exponentiation Operator](#es2016-properties--exponentiation-operator)
+1. [Iterators and Generators](#iterators-and-generators)
+1. [Modules](#modules)
+
+  <a name="tc39-proposals"></a>
+  - [28.2](#tc39-proposals) Do not use [TC39 proposals](https://github.com/tc39/proposals) that have not reached stage 3.
+
+    > Why? [They are not finalized](https://tc39.github.io/process-document/), and they are subject to change or to be withdrawn entirely. We want to use JavaScript, and proposals are not JavaScript yet.
+
+## Standard Library
+
+The [Standard Library](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects)
+contains utilities that are functionally broken but remain for legacy reasons.
+
+
+### Use `Number.isNaN` instead of global `isNaN`.
+eslint: [`no-restricted-globals`](https://eslint.org/docs/rules/no-restricted-globals)
+
+> Why? The global `isNaN` coerces non-numbers to numbers, returning true for anything that coerces to NaN.
+> If this behavior is desired, make it explicit.
+
+```javascript
+// bad 👎
+isNaN('1.2'); // false
+isNaN('1.2.3'); // true
+
+// good 👍
+Number.isNaN('1.2.3'); // false
+Number.isNaN(Number('1.2.3')); // true
+```
+
+### Use `Number.isFinite` instead of global `isFinite`.
+eslint: [`no-restricted-globals`](https://eslint.org/docs/rules/no-restricted-globals)
+
+> Why? The global `isFinite` coerces non-numbers to numbers, returning true for anything that coerces to a finite number.
+> If this behavior is desired, make it explicit.
+
+```javascript
+// bad 👎
+isFinite('2e3'); // true
+
+// good 👍
+Number.isFinite('2e3'); // false
+Number.isFinite(parseInt('2e3', 10)); // true
+```
+
+## Testing
+
+### **Yup.**
+
+```javascript
+function foo() {
+	return true;
+}
+```
+
+
+### **No, but seriously**:
+>   - Whichever testing framework you use, you should be writing tests!
+    - Strive to write many small pure functions, and minimize where mutations occur.
+    - Be cautious about stubs and mocks - they can make your tests more brittle.
+    - We primarily use [`mocha`](https://www.npmjs.com/package/mocha) and [`jest`](https://www.npmjs.com/package/jest) at Airbnb. [`tape`](https://www.npmjs.com/package/tape) is also used occasionally for small, separate modules.
+    - 100% test coverage is a good goal to strive for, even if it’s not always practical to reach it.
+    - Whenever you fix a bug, _write a regression test_. A bug fixed without a regression test is almost certainly going to break again in the future.
+
+## Performance
+
+  - [On Layout & Web Performance](https://www.kellegous.com/j/2013/01/26/layout-performance/)
+  - [String vs Array Concat](https://jsperf.com/string-vs-array-concat/2)
+  - [Try/Catch Cost In a Loop](https://jsperf.com/try-catch-in-loop-cost/12)
+  - [Bang Function](https://jsperf.com/bang-function)
+  - [jQuery Find vs Context, Selector](https://jsperf.com/jquery-find-vs-context-sel/164)
+  - [innerHTML vs textContent for script text](https://jsperf.com/innerhtml-vs-textcontent-for-script-text)
+  - [Long String Concatenation](https://jsperf.com/ya-string-concat/38)
+  - [Are JavaScript functions like `map()`, `reduce()`, and `filter()` optimized for traversing arrays?](https://www.quora.com/JavaScript-programming-language-Are-Javascript-functions-like-map-reduce-and-filter-already-optimized-for-traversing-array/answer/Quildreen-Motta)
+
+## Resources
+
+**Learning ES6+**
+
+  - [Latest ECMA spec](https://tc39.github.io/ecma262/)
+  - [ExploringJS](http://exploringjs.com/)
+  - [ES6 Compatibility Table](https://kangax.github.io/compat-table/es6/)
+  - [Comprehensive Overview of ES6 Features](http://es6-features.org/)
+
+**Read This**
+
+  - [Standard ECMA-262](http://www.ecma-international.org/ecma-262/6.0/index.html)
+
+**Tools**
+
+  - Code Style Linters
+    - [ESlint](https://eslint.org/) - [Airbnb Style .eslintrc](https://github.com/airbnb/javascript/blob/master/linters/.eslintrc)
+    - [JSHint](http://jshint.com/) - [Airbnb Style .jshintrc](https://github.com/airbnb/javascript/blob/master/linters/.jshintrc)
+  - Neutrino Preset - [@neutrinojs/airbnb](https://neutrinojs.org/packages/airbnb/)
+
+**Other Style Guides**
+
+  - [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html)
+  - [Google JavaScript Style Guide (Old)](https://google.github.io/styleguide/javascriptguide.xml)
+  - [jQuery Core Style Guidelines](https://contribute.jquery.org/style-guide/js/)
+  - [Principles of Writing Consistent, Idiomatic JavaScript](https://github.com/rwaldron/idiomatic.js)
+  - [StandardJS](https://standardjs.com)
+
+**Other Styles**
+
+  - [Naming this in nested functions](https://gist.github.com/cjohansen/4135065) - Christian Johansen
+  - [Conditional Callbacks](https://github.com/airbnb/javascript/issues/52) - Ross Allen
+  - [Popular JavaScript Coding Conventions on GitHub](http://sideeffect.kr/popularconvention/#javascript) - JeongHoon Byun
+  - [Multiple var statements in JavaScript, not superfluous](http://benalman.com/news/2012/05/multiple-var-statements-javascript/) - Ben Alman
+
+**Further Reading**
+
+  - [Understanding JavaScript Closures](https://javascriptweblog.wordpress.com/2010/10/25/understanding-javascript-closures/) - Angus Croll
+  - [Basic JavaScript for the impatient programmer](http://www.2ality.com/2013/06/basic-javascript.html) - Dr. Axel Rauschmayer
+  - [You Might Not Need jQuery](http://youmightnotneedjquery.com/) - Zack Bloom & Adam Schwartz
+  - [ES6 Features](https://github.com/lukehoban/es6features) - Luke Hoban
+  - [Frontend Guidelines](https://github.com/bendc/frontend-guidelines) - Benjamin De Cock
+
+**Books**
+
+  - [JavaScript: The Good Parts](https://www.amazon.com/JavaScript-Good-Parts-Douglas-Crockford/dp/0596517742) - Douglas Crockford
+  - [JavaScript Patterns](https://www.amazon.com/JavaScript-Patterns-Stoyan-Stefanov/dp/0596806752) - Stoyan Stefanov
+  - [Pro JavaScript Design Patterns](https://www.amazon.com/JavaScript-Design-Patterns-Recipes-Problem-Solution/dp/159059908X) - Ross Harmes and Dustin Diaz
+  - [High Performance Web Sites: Essential Knowledge for Front-End Engineers](https://www.amazon.com/High-Performance-Web-Sites-Essential/dp/0596529309) - Steve Souders
+  - [Maintainable JavaScript](https://www.amazon.com/Maintainable-JavaScript-Nicholas-C-Zakas/dp/1449327680) - Nicholas C. Zakas
+  - [JavaScript Web Applications](https://www.amazon.com/JavaScript-Web-Applications-Alex-MacCaw/dp/144930351X) - Alex MacCaw
+  - [Pro JavaScript Techniques](https://www.amazon.com/Pro-JavaScript-Techniques-John-Resig/dp/1590597273) - John Resig
+  - [Smashing Node.js: JavaScript Everywhere](https://www.amazon.com/Smashing-Node-js-JavaScript-Everywhere-Magazine/dp/1119962595) - Guillermo Rauch
+  - [Secrets of the JavaScript Ninja](https://www.amazon.com/Secrets-JavaScript-Ninja-John-Resig/dp/193398869X) - John Resig and Bear Bibeault
+  - [Human JavaScript](http://humanjavascript.com/) - Henrik Joreteg
+  - [Superhero.js](http://superherojs.com/) - Kim Joar Bekkelund, Mads Mobæk, & Olav Bjorkoy
+  - [JSBooks](http://jsbooks.revolunet.com/) - Julien Bouquillon
+  - [Third Party JavaScript](https://www.manning.com/books/third-party-javascript) - Ben Vinegar and Anton Kovalyov
+  - [Effective JavaScript: 68 Specific Ways to Harness the Power of JavaScript](http://amzn.com/0321812182) - David Herman
+  - [Eloquent JavaScript](http://eloquentjavascript.net/) - Marijn Haverbeke
+  - [You Don’t Know JS: ES6 & Beyond](http://shop.oreilly.com/product/0636920033769.do) - Kyle Simpson
+
+**Blogs**
+
+  - [JavaScript Weekly](http://javascriptweekly.com/)
+  - [JavaScript, JavaScript...](https://javascriptweblog.wordpress.com/)
+  - [Bocoup Weblog](https://bocoup.com/weblog)
+  - [Adequately Good](http://www.adequatelygood.com/)
+  - [NCZOnline](https://www.nczonline.net/)
+  - [Perfection Kills](http://perfectionkills.com/)
+  - [Ben Alman](http://benalman.com/)
+  - [Dmitry Baranovskiy](http://dmitry.baranovskiy.com/)
+  - [nettuts](http://code.tutsplus.com/?s=javascript)
+
+**Podcasts**
+
+  - [JavaScript Air](https://javascriptair.com/)
+  - [JavaScript Jabber](https://devchat.tv/js-jabber/)
+
+## Versioning
+
+We use Major.Minor.Batch style for styles versioning. For the versions available, see the [tags on this repository].
+
+## Authors
+
+- Girish Dhote <gdhote@wwnorton.com>
+- W. W. Norton Digital Engineering Team

--- a/docs/react-style.md
+++ b/docs/react-style.md
@@ -1,0 +1,703 @@
+---
+name: React Style
+route: /guides/react-style
+menu: Guides
+---
+
+> W.W. Norton & Company recommends using the [Airbnb React/JSX style guide](https://github.com/airbnb/javascript/tree/master/react).
+
+# Airbnb React/JSX Style Guide
+
+This style guide is mostly based on the standards that are currently prevalent in JavaScript, although some conventions (i.e async/await or static class fields) may still be included or prohibited on a case-by-case basis. Currently, anything prior to stage 3 is not included nor recommended in this guide.
+
+## Basic Rules
+
+  - Only include one React component per file.
+    - However, multiple [Stateless, or Pure, Components](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions) are allowed per file. eslint: [`react/no-multi-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md#ignorestateless).
+  - Always use JSX syntax.
+  - Do not use `React.createElement` unless you’re initializing the app from a file that is not JSX.
+  - [`react/forbid-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-prop-types.md) will allow `arrays` and `objects` only if it is explicitly noted what `array` and `object` contains, using `arrayOf`, `objectOf`, or `shape`.
+
+## Class vs `React.createClass` vs stateless
+
+  - If you have internal state and/or refs, prefer `class extends React.Component` over `React.createClass`. eslint: [`react/prefer-es6-class`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md) [`react/prefer-stateless-function`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)
+
+    ```jsx
+    // bad
+    const Listing = React.createClass({
+      // ...
+      render() {
+        return <div>{this.state.hello}</div>;
+      }
+    });
+
+    // good
+    class Listing extends React.Component {
+      // ...
+      render() {
+        return <div>{this.state.hello}</div>;
+      }
+    }
+    ```
+
+    And if you don’t have state or refs, prefer normal functions (not arrow functions) over classes:
+
+    ```jsx
+    // bad
+    class Listing extends React.Component {
+      render() {
+        return <div>{this.props.hello}</div>;
+      }
+    }
+
+    // bad (relying on function name inference is discouraged)
+    const Listing = ({ hello }) => (
+      <div>{hello}</div>
+    );
+
+    // good
+    function Listing({ hello }) {
+      return <div>{hello}</div>;
+    }
+    ```
+
+## Mixins
+
+  - [Do not use mixins](https://facebook.github.io/react/blog/2016/07/13/mixins-considered-harmful.html).
+
+  > Why? Mixins introduce implicit dependencies, cause name clashes, and cause snowballing complexity. Most use cases for mixins can be accomplished in better ways via components, higher-order components, or utility modules.
+
+## Naming
+
+  - **Extensions**: Use `.jsx` extension for React components. eslint: [`react/jsx-filename-extension`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md)
+  - **Filename**: Use PascalCase for filenames. E.g., `ReservationCard.jsx`.
+  - **Reference Naming**: Use PascalCase for React components and camelCase for their instances. eslint: [`react/jsx-pascal-case`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
+
+    ```jsx
+    // bad
+    import reservationCard from './ReservationCard';
+
+    // good
+    import ReservationCard from './ReservationCard';
+
+    // bad
+    const ReservationItem = <ReservationCard />;
+
+    // good
+    const reservationItem = <ReservationCard />;
+    ```
+
+  - **Component Naming**: Use the filename as the component name. For example, `ReservationCard.jsx` should have a reference name of `ReservationCard`. However, for root components of a directory, use `index.jsx` as the filename and use the directory name as the component name:
+
+    ```jsx
+    // bad
+    import Footer from './Footer/Footer';
+
+    // bad
+    import Footer from './Footer/index';
+
+    // good
+    import Footer from './Footer';
+    ```
+
+  - **Higher-order Component Naming**: Use a composite of the higher-order component’s name and the passed-in component’s name as the `displayName` on the generated component. For example, the higher-order component `withFoo()`, when passed a component `Bar` should produce a component with a `displayName` of `withFoo(Bar)`.
+
+    > Why? A component’s `displayName` may be used by developer tools or in error messages, and having a value that clearly expresses this relationship helps people understand what is happening.
+
+    ```jsx
+    // bad
+    export default function withFoo(WrappedComponent) {
+      return function WithFoo(props) {
+        return <WrappedComponent {...props} foo />;
+      }
+    }
+
+    // good
+    export default function withFoo(WrappedComponent) {
+      function WithFoo(props) {
+        return <WrappedComponent {...props} foo />;
+      }
+
+      const wrappedComponentName = WrappedComponent.displayName
+        || WrappedComponent.name
+        || 'Component';
+
+      WithFoo.displayName = `withFoo(${wrappedComponentName})`;
+      return WithFoo;
+    }
+    ```
+
+  - **Props Naming**: Avoid using DOM component prop names for different purposes.
+
+    > Why? People expect props like `style` and `className` to mean one specific thing. Varying this API for a subset of your app makes the code less readable and less maintainable, and may cause bugs.
+
+    ```jsx
+    // bad
+    <MyComponent style="fancy" />
+
+    // bad
+    <MyComponent className="fancy" />
+
+    // good
+    <MyComponent variant="fancy" />
+    ```
+
+## Declaration
+
+  - Do not use `displayName` for naming components. Instead, name the component by reference.
+
+    ```jsx
+    // bad
+    export default React.createClass({
+      displayName: 'ReservationCard',
+      // stuff goes here
+    });
+
+    // good
+    export default class ReservationCard extends React.Component {
+    }
+    ```
+
+## Alignment
+
+  - Follow these alignment styles for JSX syntax. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md) [`react/jsx-closing-tag-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md)
+
+    ```jsx
+    // bad
+    <Foo superLongParam="bar"
+         anotherSuperLongParam="baz" />
+
+    // good
+    <Foo
+      superLongParam="bar"
+      anotherSuperLongParam="baz"
+    />
+
+    // if props fit in one line then keep it on the same line
+    <Foo bar="bar" />
+
+    // children get indented normally
+    <Foo
+      superLongParam="bar"
+      anotherSuperLongParam="baz"
+    >
+      <Quux />
+    </Foo>
+
+    // bad
+    {showButton &&
+      <Button />
+    }
+
+    // bad
+    {
+      showButton &&
+        <Button />
+    }
+
+    // good
+    {showButton && (
+      <Button />
+    )}
+
+    // good
+    {showButton && <Button />}
+    ```
+
+## Quotes
+
+  - Always use double quotes (`"`) for JSX attributes, but single quotes (`'`) for all other JS. eslint: [`jsx-quotes`](https://eslint.org/docs/rules/jsx-quotes)
+
+    > Why? Regular HTML attributes also typically use double quotes instead of single, so JSX attributes mirror this convention.
+
+    ```jsx
+    // bad
+    <Foo bar='bar' />
+
+    // good
+    <Foo bar="bar" />
+
+    // bad
+    <Foo style={{ left: "20px" }} />
+
+    // good
+    <Foo style={{ left: '20px' }} />
+    ```
+
+## Spacing
+
+  - Always include a single space in your self-closing tag. eslint: [`no-multi-spaces`](https://eslint.org/docs/rules/no-multi-spaces), [`react/jsx-tag-spacing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md)
+
+    ```jsx
+    // bad
+    <Foo/>
+
+    // very bad
+    <Foo                 />
+
+    // bad
+    <Foo
+     />
+
+    // good
+    <Foo />
+    ```
+
+  - Do not pad JSX curly braces with spaces. eslint: [`react/jsx-curly-spacing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md)
+
+    ```jsx
+    // bad
+    <Foo bar={ baz } />
+
+    // good
+    <Foo bar={baz} />
+    ```
+
+## Props
+
+  - Always use camelCase for prop names.
+
+    ```jsx
+    // bad
+    <Foo
+      UserName="hello"
+      phone_number={12345678}
+    />
+
+    // good
+    <Foo
+      userName="hello"
+      phoneNumber={12345678}
+    />
+    ```
+
+  - Omit the value of the prop when it is explicitly `true`. eslint: [`react/jsx-boolean-value`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md)
+
+    ```jsx
+    // bad
+    <Foo
+      hidden={true}
+    />
+
+    // good
+    <Foo
+      hidden
+    />
+
+    // good
+    <Foo hidden />
+    ```
+
+  - Always include an `alt` prop on `<img>` tags. If the image is presentational, `alt` can be an empty string or the `<img>` must have `role="presentation"`. eslint: [`jsx-a11y/alt-text`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md)
+
+    ```jsx
+    // bad
+    <img src="hello.jpg" />
+
+    // good
+    <img src="hello.jpg" alt="Me waving hello" />
+
+    // good
+    <img src="hello.jpg" alt="" />
+
+    // good
+    <img src="hello.jpg" role="presentation" />
+    ```
+
+  - Do not use words like "image", "photo", or "picture" in `<img>` `alt` props. eslint: [`jsx-a11y/img-redundant-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/img-redundant-alt.md)
+
+    > Why? Screenreaders already announce `img` elements as images, so there is no need to include this information in the alt text.
+
+    ```jsx
+    // bad
+    <img src="hello.jpg" alt="Picture of me waving hello" />
+
+    // good
+    <img src="hello.jpg" alt="Me waving hello" />
+    ```
+
+  - Use only valid, non-abstract [ARIA roles](https://www.w3.org/TR/wai-aria/#usage_intro). eslint: [`jsx-a11y/aria-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-role.md)
+
+    ```jsx
+    // bad - not an ARIA role
+    <div role="datepicker" />
+
+    // bad - abstract ARIA role
+    <div role="range" />
+
+    // good
+    <div role="button" />
+    ```
+
+  - Do not use `accessKey` on elements. eslint: [`jsx-a11y/no-access-key`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-access-key.md)
+
+  > Why? Inconsistencies between keyboard shortcuts and keyboard commands used by people using screenreaders and keyboards complicate accessibility.
+
+  ```jsx
+  // bad
+  <div accessKey="h" />
+
+  // good
+  <div />
+  ```
+
+  - Avoid using an array index as `key` prop, prefer a stable ID. eslint: [`react/no-array-index-key`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md)
+
+> Why? Not using a stable ID [is an anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318) because it can negatively impact performance and cause issues with component state.
+
+We don’t recommend using indexes for keys if the order of items may change.
+
+  ```jsx
+  // bad
+  {todos.map((todo, index) =>
+    <Todo
+      {...todo}
+      key={index}
+    />
+  )}
+
+  // good
+  {todos.map(todo => (
+    <Todo
+      {...todo}
+      key={todo.id}
+    />
+  ))}
+  ```
+
+  - Always define explicit defaultProps for all non-required props.
+
+  > Why? propTypes are a form of documentation, and providing defaultProps means the reader of your code doesn’t have to assume as much. In addition, it can mean that your code can omit certain type checks.
+
+  ```jsx
+  // bad
+  function SFC({ foo, bar, children }) {
+    return <div>{foo}{bar}{children}</div>;
+  }
+  SFC.propTypes = {
+    foo: PropTypes.number.isRequired,
+    bar: PropTypes.string,
+    children: PropTypes.node,
+  };
+
+  // good
+  function SFC({ foo, bar, children }) {
+    return <div>{foo}{bar}{children}</div>;
+  }
+  SFC.propTypes = {
+    foo: PropTypes.number.isRequired,
+    bar: PropTypes.string,
+    children: PropTypes.node,
+  };
+  SFC.defaultProps = {
+    bar: '',
+    children: null,
+  };
+  ```
+
+  - Use spread props sparingly.
+  > Why? Otherwise you’re more likely to pass unnecessary props down to components. And for React v15.6.1 and older, you could [pass invalid HTML attributes to the DOM](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html).
+
+  Exceptions:
+
+  - HOCs that proxy down props and hoist propTypes
+
+  ```jsx
+  function HOC(WrappedComponent) {
+    return class Proxy extends React.Component {
+      Proxy.propTypes = {
+        text: PropTypes.string,
+        isLoading: PropTypes.bool
+      };
+
+      render() {
+        return <WrappedComponent {...this.props} />
+      }
+    }
+  }
+  ```
+
+  - Spreading objects with known, explicit props. This can be particularly useful when testing React components with Mocha’s beforeEach construct.
+
+  ```jsx
+  export default function Foo {
+    const props = {
+      text: '',
+      isPublished: false
+    }
+
+    return (<div {...props} />);
+  }
+  ```
+
+  Notes for use:
+  Filter out unnecessary props when possible. Also, use [prop-types-exact](https://www.npmjs.com/package/prop-types-exact) to help prevent bugs.
+
+  ```jsx
+  // bad
+  render() {
+    const { irrelevantProp, ...relevantProps } = this.props;
+    return <WrappedComponent {...this.props} />
+  }
+
+  // good
+  render() {
+    const { irrelevantProp, ...relevantProps } = this.props;
+    return <WrappedComponent {...relevantProps} />
+  }
+  ```
+
+## Refs
+
+  - Always use ref callbacks. eslint: [`react/no-string-refs`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md)
+
+    ```jsx
+    // bad
+    <Foo
+      ref="myRef"
+    />
+
+    // good
+    <Foo
+      ref={(ref) => { this.myRef = ref; }}
+    />
+    ```
+
+## Parentheses
+
+  - Wrap JSX tags in parentheses when they span more than one line. eslint: [`react/jsx-wrap-multilines`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-wrap-multilines.md)
+
+    ```jsx
+    // bad
+    render() {
+      return <MyComponent variant="long body" foo="bar">
+               <MyChild />
+             </MyComponent>;
+    }
+
+    // good
+    render() {
+      return (
+        <MyComponent variant="long body" foo="bar">
+          <MyChild />
+        </MyComponent>
+      );
+    }
+
+    // good, when single line
+    render() {
+      const body = <div>hello</div>;
+      return <MyComponent>{body}</MyComponent>;
+    }
+    ```
+
+## Tags
+
+  - Always self-close tags that have no children. eslint: [`react/self-closing-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md)
+
+    ```jsx
+    // bad
+    <Foo variant="stuff"></Foo>
+
+    // good
+    <Foo variant="stuff" />
+    ```
+
+  - If your component has multiline properties, close its tag on a new line. eslint: [`react/jsx-closing-bracket-location`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md)
+
+    ```jsx
+    // bad
+    <Foo
+      bar="bar"
+      baz="baz" />
+
+    // good
+    <Foo
+      bar="bar"
+      baz="baz"
+    />
+    ```
+
+## Methods
+
+  - Use arrow functions to close over local variables. It is handy when you need to pass additional data to an event handler. Although, make sure they [do not massively hurt performance](https://www.bignerdranch.com/blog/choosing-the-best-approach-for-react-event-handlers/), in particular when passed to custom components that might be PureComponents, because they will trigger a possibly needless rerender every time.
+
+    ```jsx
+    function ItemList(props) {
+      return (
+        <ul>
+          {props.items.map((item, index) => (
+            <Item
+              key={item.key}
+              onClick={(event) => { doSomethingWith(event, item.name, index); }}
+            />
+          ))}
+        </ul>
+      );
+    }
+    ```
+
+  - Bind event handlers for the render method in the constructor. eslint: [`react/jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)
+
+    > Why? A bind call in the render path creates a brand new function on every single render. Do not use arrow functions in class fields, because it makes them [challenging to test and debug, and can negatively impact performance](https://medium.com/@charpeni/arrow-functions-in-class-properties-might-not-be-as-great-as-we-think-3b3551c440b1), and because conceptually, class fields are for data, not logic.
+
+    ```jsx
+    // bad
+    class extends React.Component {
+      onClickDiv() {
+        // do stuff
+      }
+
+      render() {
+        return <div onClick={this.onClickDiv.bind(this)} />;
+      }
+    }
+
+    // very bad
+    class extends React.Component {
+      onClickDiv = () => {
+        // do stuff
+      }
+
+      render() {
+        return <div onClick={this.onClickDiv} />
+      }
+    }
+
+    // good
+    class extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.onClickDiv = this.onClickDiv.bind(this);
+      }
+
+      onClickDiv() {
+        // do stuff
+      }
+
+      render() {
+        return <div onClick={this.onClickDiv} />;
+      }
+    }
+    ```
+
+  - Do not use underscore prefix for internal methods of a React component.
+    > Why? Underscore prefixes are sometimes used as a convention in other languages to denote privacy. But, unlike those languages, there is no native support for privacy in JavaScript, everything is public. Regardless of your intentions, adding underscore prefixes to your properties does not actually make them private, and any property (underscore-prefixed or not) should be treated as being public. See issues [#1024](https://github.com/airbnb/javascript/issues/1024), and [#490](https://github.com/airbnb/javascript/issues/490) for a more in-depth discussion.
+
+    ```jsx
+    // bad
+    React.createClass({
+      _onClickSubmit() {
+        // do stuff
+      },
+
+      // other stuff
+    });
+
+    // good
+    class extends React.Component {
+      onClickSubmit() {
+        // do stuff
+      }
+
+      // other stuff
+    }
+    ```
+
+  - Be sure to return a value in your `render` methods. eslint: [`react/require-render-return`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)
+
+    ```jsx
+    // bad
+    render() {
+      (<div />);
+    }
+
+    // good
+    render() {
+      return (<div />);
+    }
+    ```
+
+## Ordering
+
+  - Ordering for `class extends React.Component`:
+
+  1. optional `static` methods
+  2. `constructor`
+  3. `getChildContext`
+  4. `componentWillMount`
+  5. `componentDidMount`
+  6. `componentWillReceiveProps`
+  7. `shouldComponentUpdate`
+  8. `componentWillUpdate`
+  9. `componentDidUpdate`
+  10. `componentWillUnmount`
+  11. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`
+  12. *getter methods for `render`* like `getSelectReason()` or `getFooterContent()`
+  13. *optional render methods* like `renderNavigation()` or `renderProfilePicture()`
+  14. `render`
+
+  - How to define `propTypes`, `defaultProps`, `contextTypes`, etc...
+
+    ```jsx
+    import React from 'react';
+    import PropTypes from 'prop-types';
+
+    const propTypes = {
+      id: PropTypes.number.isRequired,
+      url: PropTypes.string.isRequired,
+      text: PropTypes.string,
+    };
+
+    const defaultProps = {
+      text: 'Hello World',
+    };
+
+    class Link extends React.Component {
+      static methodsAreOk() {
+        return true;
+      }
+
+      render() {
+        return <a href={this.props.url} data-id={this.props.id}>{this.props.text}</a>;
+      }
+    }
+
+    Link.propTypes = propTypes;
+    Link.defaultProps = defaultProps;
+
+    export default Link;
+    ```
+
+  - Ordering for `React.createClass`: eslint: [`react/sort-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md)
+
+  1. `displayName`
+  2. `propTypes`
+  3. `contextTypes`
+  4. `childContextTypes`
+  5. `mixins`
+  6. `statics`
+  7. `defaultProps`
+  8. `getDefaultProps`
+  9. `getInitialState`
+  10. `getChildContext`
+  11. `componentWillMount`
+  12. `componentDidMount`
+  13. `componentWillReceiveProps`
+  14. `shouldComponentUpdate`
+  15. `componentWillUpdate`
+  16. `componentDidUpdate`
+  17. `componentWillUnmount`
+  18. *clickHandlers or eventHandlers* like `onClickSubmit()` or `onChangeDescription()`
+  19. *getter methods for `render`* like `getSelectReason()` or `getFooterContent()`
+  20. *optional render methods* like `renderNavigation()` or `renderProfilePicture()`
+  21. `render`
+
+## `isMounted`
+
+  - Do not use `isMounted`. eslint: [`react/no-is-mounted`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)
+
+  > Why? [`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and is on its way to being officially deprecated.
+
+  [anti-pattern]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html

--- a/docs/typescript-style.md
+++ b/docs/typescript-style.md
@@ -1,0 +1,271 @@
+---
+name: Typescript Style
+route: /guides/typescript-style
+menu: Guides
+---
+
+# Typescript Style
+
+## Variable and Function
+* Use `camelCase` for variable and function names
+
+> Reason: Conventional JavaScript
+
+**Bad**
+```ts
+var FooVar;
+function BarFunc() { }
+```
+**Good**
+```ts
+var fooVar;
+function barFunc() { }
+```
+
+## Class
+* Use `PascalCase` for class names.
+
+> Reason: This is actually fairly conventional in standard JavaScript.
+
+**Bad**
+```ts
+class foo { }
+```
+**Good**
+```ts
+class Foo { }
+```
+* Use `camelCase` of class members and methods
+
+> Reason: Naturally follows from variable and function naming convention.
+
+**Bad**
+```ts
+class Foo {
+    Bar: number;
+    Baz() { }
+}
+```
+**Good**
+```ts
+class Foo {
+    bar: number;
+    baz() { }
+}
+```
+## Interface
+
+* Use `PascalCase` for name.
+
+> Reason: Similar to class
+
+* Use `camelCase` for members.
+
+> Reason: Similar to class
+
+* **Don't** prefix with `I`
+
+> Reason: Unconventional. `lib.d.ts` defines important interfaces without an `I` (e.g. Window, Document etc).
+
+**Bad**
+```ts
+interface IFoo {
+}
+```
+**Good**
+```ts
+interface Foo {
+}
+```
+
+## Type
+
+* Use `PascalCase` for name.
+
+> Reason: Similar to class
+
+* Use `camelCase` for members.
+
+> Reason: Similar to class
+
+
+## Namespace
+
+* Use `PascalCase` for names
+
+> Reason: Convention followed by the TypeScript team. Namespaces are effectively just a class with static members. Class names are `PascalCase` => Namespace names are `PascalCase`
+
+**Bad**
+```ts
+namespace foo {
+}
+```
+**Good**
+```ts
+namespace Foo {
+}
+```
+
+## Enum
+
+* Use `PascalCase` for enum names
+
+> Reason: Similar to Class. Is a Type.
+
+**Bad**
+```ts
+enum color {
+}
+```
+**Good**
+```ts
+enum Color {
+}
+```
+
+* Use `PascalCase` for enum member
+
+> Reason: Convention followed by TypeScript team i.e. the language creators e.g `SyntaxKind.StringLiteral`. Also helps with translation (code generation) of other languages into TypeScript.
+
+**Bad**
+```ts
+enum Color {
+    red
+}
+```
+**Good**
+```ts
+enum Color {
+    Red
+}
+```
+
+## Null vs. Undefined
+
+* Prefer not to use either for explicit unavailability
+
+> Reason: these values are commonly used to keep a consistent structure between values. In TypeScript you use *types* to denote the structure
+
+**Bad**
+```ts
+let foo = {x:123,y:undefined};
+```
+**Good**
+```ts
+let foo:{x:number,y?:number} = {x:123};
+```
+
+* Use `undefined` in general (do consider returning an object like `{valid:boolean,value?:Foo}` instead)
+
+***Bad***
+```ts
+return null;
+```
+***Good***
+```ts
+return undefined;
+```
+
+* Use `null` where its a part of the API or conventional
+
+> Reason: It is conventional in Node.js e.g. `error` is `null` for NodeBack style callbacks.
+
+**Bad**
+```ts
+cb(undefined)
+```
+**Good**
+```ts
+cb(null)
+```
+
+* Use *truthy* check for **objects** being `null` or `undefined`
+
+**Bad**
+```ts
+if (error === null)
+```
+**Good**
+```ts
+if (error)
+```
+
+* Use `== null` / `!= null` (not `===` / `!==`) to check for `null` / `undefined` on primitives as it works for both `null`/`undefined` but not other falsy values (like `''`,`0`,`false`) e.g.
+
+**Bad**
+```ts
+if (error !== null) // does not rule out undefined
+```
+**Good**
+```ts
+if (error != null) // rules out both null and undefined
+```
+
+## Formatting
+The TypeScript compiler ships with a very nice formatting language service. Whatever output it gives by default is good enough to reduce the cognitive overload on the team.
+
+Use [`tsfmt`](https://github.com/vvakame/typescript-formatter) to automatically format your code on the command line. Also your IDE (atom/vscode/vs/sublime) already has formatting support built-in.
+
+Examples:
+```ts
+// Space before type i.e. foo:<space>string
+const foo: string = "hello";
+```
+
+## Quotes
+
+* Prefer single quotes (`'`) unless escaping.
+
+> Reason: More JavaScript teams do this (e.g. [airbnb](https://github.com/airbnb/javascript), [standard](https://github.com/feross/standard), [npm](https://github.com/npm/npm), [node](https://github.com/nodejs/node), [google/angular](https://github.com/angular/angular/), [facebook/react](https://github.com/facebook/react)). Its easier to type (no shift needed on most keyboards). [Prettier team recommends single quotes as well](https://github.com/prettier/prettier/issues/1105)
+
+> Double quotes are not without merit: Allows easier copy paste of objects into JSON. Allows people to use other languages to work without changing their quote character. Allows you to use apostrophes e.g. `He's not going.`. But I'd rather not deviate from where the JS Community is fairly decided.
+
+* When you can't use double quotes, try using back ticks (\`).
+
+> Reason: These generally represent the intent of complex enough strings.
+
+## Spaces
+
+* Use `2` spaces. Not tabs.
+
+> Reason: More JavaScript teams do this (e.g. [airbnb](https://github.com/airbnb/javascript), [idiomatic](https://github.com/rwaldron/idiomatic.js), [standard](https://github.com/feross/standard), [npm](https://github.com/npm/npm), [node](https://github.com/nodejs/node), [google/angular](https://github.com/angular/angular/), [facebook/react](https://github.com/facebook/react)). The TypeScript/VSCode teams use 4 spaces but are definitely the exception in the ecosystem.
+
+## Semicolons
+
+* Use semicolons.
+
+> Reasons: Explicit semicolons helps language formatting tools give consistent results. Missing ASI (automatic semicolon insertion) can trip new devs e.g. `foo() \n (function(){})` will be a single statement (not two). TC39 [warning on this as well](https://github.com/tc39/ecma262/pull/1062). Example teams: [airbnb](https://github.com/airbnb/javascript), [idiomatic](https://github.com/rwaldron/idiomatic.js), [google/angular](https://github.com/angular/angular/), [facebook/react](https://github.com/facebook/react), [Microsoft/TypeScript](https://github.com/Microsoft/TypeScript/).
+
+## Array
+
+* Annotate arrays as `foos:Foo[]` instead of `foos:Array<Foo>`.
+
+> Reasons: Its easier to read. Its used by the TypeScript team. Makes easier to know something is an array as the mind is trained to detect `[]`.
+
+## Filename
+Name files with `camelCase`. E.g. `accordion.tsx`, `myControl.tsx`, `utils.ts`, `map.ts` etc.
+
+> Reason: Conventional across many JS teams.
+
+## type vs. interface
+
+* Use `type` when you *might* need a union or intersection:
+
+```
+type Foo = number | { someProperty: number }
+```
+* Use `interface` when you want `extends` or `implements` e.g
+
+```
+interface Foo {
+  foo: string;
+}
+interface FooBar extends Foo {
+  bar: string;
+}
+class X implements FooBar {
+  foo: string;
+  bar: string;
+}
+```
+* Otherwise use whatever makes you happy that day.


### PR DESCRIPTION
This moves the documentation out of [wwnorton/design-system](https://github.com/wwnorton/design-system) and into a /docs directory here. I also removed the `x` from the file extensions since they're normal Markdown and don't actually use any of the extensions that MDX provides.

This should be fairly easy to deploy with [GitHub Pages](https://pages.github.com/). You could either [set a theme](https://github.com/wwnorton/style/settings/pages/themes?source=gh-pages), use some other static site generator like [Hugo](https://github.com/gohugoio/hugo), [VuePress](https://github.com/vuejs/vuepress), or [Gatsby](https://github.com/gatsbyjs/gatsby) to render the files (GH Pages uses [Jekyll](https://github.com/jekyll/jekyll) by default), or just move these files to folders somewhere in the repo and link to them in the root README since GitHub will also render them.